### PR TITLE
Add Firebase Storage upload flow for Nano Banana images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A production-ready Next.js template with Firebase Authentication featuring Googl
 - 🔑 **Email/Password Auth** - Traditional login and registration
 - 🚀 **Google OAuth** - One-click Google sign-in
 - 🗄️ **Firestore Ready** - Database integration prepared
+- 🖼️ **Firebase Storage** - Save Nano Banana images directly to your bucket
 - 🎨 **Modern UI** - Clean design with Tailwind CSS
 - 📱 **Responsive Design** - Mobile-first approach
 - 🌙 **Dark Mode Support** - Automatic theme switching

--- a/src/app/api/nano-banana-image/route.ts
+++ b/src/app/api/nano-banana-image/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface NanoBananaImageRequest {
+  imageUrl?: string
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = (await request.json()) as NanoBananaImageRequest
+    const imageUrl = body.imageUrl?.trim()
+
+    if (!imageUrl) {
+      return NextResponse.json({ error: 'imageUrl is required' }, { status: 400 })
+    }
+
+    if (!imageUrl.startsWith('http://') && !imageUrl.startsWith('https://')) {
+      return NextResponse.json({ error: 'imageUrl must be an absolute URL' }, { status: 400 })
+    }
+
+    const response = await fetch(imageUrl)
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch image: ${response.status} ${response.statusText}` },
+        { status: response.status }
+      )
+    }
+
+    const contentType = response.headers.get('content-type') ?? 'application/octet-stream'
+    const arrayBuffer = await response.arrayBuffer()
+    const data = Buffer.from(arrayBuffer).toString('base64')
+
+    return NextResponse.json({ contentType, data })
+  } catch (error) {
+    console.error('Error retrieving Nano Banana image:', error)
+    return NextResponse.json({ error: 'Failed to retrieve Nano Banana image' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/context/AuthContext'
 import LoginForm from '@/components/LoginForm'
 import UserProfile from '@/components/UserProfile'
 import FirestoreDemo from '@/components/FirestoreDemo'
+import NanoBananaImageUploader from '@/components/NanoBananaImageUploader'
 
 export default function Home() {
   const { user } = useAuth()
@@ -57,6 +58,7 @@ export default function Home() {
           <>
             <UserProfile />
             <FirestoreDemo />
+            <NanoBananaImageUploader />
           </>
         )}
 

--- a/src/components/NanoBananaImageUploader.tsx
+++ b/src/components/NanoBananaImageUploader.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { storage } from '@/lib/firebase'
+import { useAuth } from '@/context/AuthContext'
+
+interface NanoBananaResponse {
+  contentType: string
+  data: string
+}
+
+const decodeBase64ToUint8Array = (base64Data: string): Uint8Array => {
+  const normalized = base64Data.replace(/\s/g, '')
+  const binaryString = atob(normalized)
+  const length = binaryString.length
+  const bytes = new Uint8Array(length)
+
+  for (let index = 0; index < length; index += 1) {
+    bytes[index] = binaryString.charCodeAt(index)
+  }
+
+  return bytes
+}
+
+export default function NanoBananaImageUploader(): JSX.Element | null {
+  const { user } = useAuth()
+  const [imageUrl, setImageUrl] = useState('')
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState('')
+  const [storagePath, setStoragePath] = useState('')
+  const [downloadUrl, setDownloadUrl] = useState('')
+
+  if (!user) {
+    return null
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!imageUrl.trim()) {
+      setError('Please provide the Nano Banana image URL before uploading.')
+      return
+    }
+
+    try {
+      setUploading(true)
+      setError('')
+      setStoragePath('')
+      setDownloadUrl('')
+
+      const response = await fetch('/api/nano-banana-image', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ imageUrl: imageUrl.trim() })
+      })
+
+      if (!response.ok) {
+        let message = 'Unable to fetch the Nano Banana image.'
+
+        try {
+          const errorData = (await response.json()) as { error?: string }
+          if (errorData?.error) {
+            message = errorData.error
+          }
+        } catch (parseError) {
+          console.error('Failed to parse Nano Banana error response:', parseError)
+        }
+
+        throw new Error(message)
+      }
+
+      const data = (await response.json()) as NanoBananaResponse
+      const bytes = decodeBase64ToUint8Array(data.data)
+      const now = new Date()
+      const path = `nano-banana/${user.uid}/${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getTime()}`
+      const storageReference = ref(storage, path)
+
+      await uploadBytes(storageReference, bytes, { contentType: data.contentType })
+      const url = await getDownloadURL(storageReference)
+
+      setStoragePath(path)
+      setDownloadUrl(url)
+      setImageUrl('')
+    } catch (uploadError) {
+      console.error('Failed to store Nano Banana image:', uploadError)
+      setError(uploadError instanceof Error ? uploadError.message : 'Failed to store Nano Banana image.')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto mt-8 p-6 bg-white rounded-lg shadow-md dark:bg-gray-800">
+      <h3 className="text-xl font-bold mb-4">Nano Banana Image Storage</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+        Paste the direct image URL returned from Nano Banana and we will download and store it securely in Firebase Storage for
+        you.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">{error}</div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="nano-banana-url" className="block text-sm font-medium mb-1">
+            Nano Banana Image URL
+          </label>
+          <input
+            id="nano-banana-url"
+            type="url"
+            value={imageUrl}
+            onChange={(event) => setImageUrl(event.target.value)}
+            placeholder="https://nano-banana.app/images/12345"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={uploading}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+        >
+          {uploading ? 'Saving to Firebase…' : 'Save to Firebase Storage'}
+        </button>
+      </form>
+
+      {(storagePath || downloadUrl) && (
+        <div className="mt-6 space-y-2">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            <span className="font-medium">Storage path:</span> {storagePath}
+          </p>
+          <a
+            href={downloadUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm text-blue-600 hover:text-blue-800"
+          >
+            View stored image
+          </a>
+          {downloadUrl && (
+            <div className="mt-4">
+              <img
+                src={downloadUrl}
+                alt="Stored Nano Banana preview"
+                className="max-h-64 w-full object-contain rounded-md border border-gray-200 dark:border-gray-700"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp, getApps } from 'firebase/app'
 import { getAuth, GoogleAuthProvider } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -19,6 +20,9 @@ export const auth = getAuth(firebase_app)
 
 // Initialize Firebase Firestore and get a reference to the service
 export const db = getFirestore(firebase_app)
+
+// Initialize Firebase Storage and get a reference to the service
+export const storage = getStorage(firebase_app)
 
 // Initialize Google Auth Provider
 export const googleProvider = new GoogleAuthProvider()


### PR DESCRIPTION
## Summary
- expose Firebase Storage from the shared Firebase client configuration
- add a Nano Banana image uploader that proxies remote images through a Next.js route and saves them to Firebase Storage
- surface the uploader for authenticated users on the home page and document the new storage capability

## Testing
- npm run lint *(fails: prompts for interactive setup so command was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8d592c608332a86e99dceec20a0d