### PR TITLE
Rework image generator hero experience

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,42 +66,54 @@ export default function Home() {
     )
   }
 
+  const wrapperClassName = [
+    'relative mx-auto flex max-w-6xl flex-col px-6 pb-24 lg:px-12',
+    user ? 'pt-16' : 'pt-24'
+  ].join(' ')
+
   return (
-    <main className="relative min-h-screen overflow-hidden">
+    <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute -top-32 left-1/2 h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl" />
         <div className="absolute bottom-0 left-1/4 h-[460px] w-[460px] rounded-full bg-indigo-500/20 blur-3xl" />
         <div className="absolute -bottom-24 right-0 h-[420px] w-[420px] rounded-full bg-purple-500/20 blur-3xl" />
       </div>
 
-      <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col px-6 pb-24 pt-24 lg:px-12">
-        <section className="text-center">
-          <span className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-200">
-            🍌 Nano Banana AI
-          </span>
-          <h1 className="mt-8 text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
-            AI-powered image generation with Firebase and Next.js
-          </h1>
-          <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-300 sm:text-xl">
-            Generate stunning images from text prompts with secure authentication, real-time data storage, and modern UI components built for rapid development.
-          </p>
-          <div className="mt-10 flex flex-wrap justify-center gap-4">
-            <a
-              href="#auth"
-              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-500/40"
-            >
-              Get started now
-            </a>
-            <a
-              href="#features"
-              className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-slate-200 transition-transform hover:-translate-y-1 hover:border-white/40 hover:text-white"
-            >
-              Explore features
-            </a>
-          </div>
-        </section>
+      {user && <ImageGenerator user={user} onLogout={logout} />}
 
-        <section id="features" className="mt-20 grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+      <div className={wrapperClassName}>
+        {!user && (
+          <section className="text-center">
+            <span className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-200">
+              🍌 Nano Banana AI
+            </span>
+            <h1 className="mt-8 text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+              Bring your ideas to life with the Nano Banana AI canvas
+            </h1>
+            <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-300 sm:text-xl">
+              Sign in to describe your dream scene and watch the generator fill the screen with rich, download-ready artwork in seconds.
+            </p>
+            <div className="mt-10 flex flex-wrap justify-center gap-4">
+              <a
+                href="#auth"
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-500/40"
+              >
+                Sign in to generate
+              </a>
+              <a
+                href="#features"
+                className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-slate-200 transition-transform hover:-translate-y-1 hover:border-white/40 hover:text-white"
+              >
+                Explore the toolkit
+              </a>
+            </div>
+          </section>
+        )}
+
+        <section
+          id="features"
+          className={`${user ? 'mt-16' : 'mt-20'} grid gap-6 sm:grid-cols-2 xl:grid-cols-4`}
+        >
           {features.map((feature) => (
             <article
               key={feature.title}
@@ -117,18 +129,17 @@ export default function Home() {
           ))}
         </section>
 
-        <section id="auth" className="mt-24 space-y-12">
-          <div className="mx-auto max-w-2xl">
-            {!user ? (
+        <section id="auth" className="mt-24">
+          {!user ? (
+            <div className="mx-auto max-w-2xl">
               <LoginForm />
-            ) : (
-              <div className="space-y-8">
-                <UserProfile />
-                <ImageGenerator user={user} onLogout={logout} />
-                <FirestoreDemo />
-              </div>
-            )}
-          </div>
+            </div>
+          ) : (
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+              <UserProfile />
+              <FirestoreDemo />
+            </div>
+          )}
         </section>
 
         <section className="mt-24">

--- a/src/components/ImageDisplay.tsx
+++ b/src/components/ImageDisplay.tsx
@@ -10,6 +10,8 @@ interface ImageDisplayProps {
   prompt: string
   onRetry?: () => void
   onClear?: () => void
+  className?: string
+  variant?: 'default' | 'hero'
 }
 
 export default function ImageDisplay({
@@ -18,7 +20,9 @@ export default function ImageDisplay({
   error,
   prompt,
   onRetry,
-  onClear
+  onClear,
+  className,
+  variant = 'default'
 }: ImageDisplayProps) {
   const [imageError, setImageError] = useState(false)
   const [isImageLoading, setIsImageLoading] = useState(true)
@@ -34,21 +38,90 @@ export default function ImageDisplay({
     setImageError(true)
   }
 
+  const isHero = variant === 'hero'
+
+  const containerClassName = [
+    isHero ? 'w-full max-w-3xl mx-auto lg:max-w-5xl xl:max-w-6xl' : 'w-full max-w-2xl mx-auto',
+    className
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const baseFrameClass = isHero
+    ? 'relative aspect-[3/4] sm:aspect-[4/5] lg:aspect-[5/6] overflow-hidden rounded-3xl border border-white/15 bg-gradient-to-br from-slate-900/70 via-slate-900/30 to-indigo-900/40 shadow-[0_40px_120px_-45px_rgba(56,189,248,0.55)] backdrop-blur-2xl'
+    : 'relative aspect-square overflow-hidden rounded-lg border-2 border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800'
+
+  const loadingBackdropClass = isHero
+    ? 'absolute inset-0 bg-gradient-to-br from-slate-800/60 via-sky-500/25 to-indigo-900/40 animate-pulse'
+    : 'absolute inset-0 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 dark:from-gray-700 dark:via-gray-600 dark:to-gray-700 animate-pulse'
+
+  const loadingSpinnerClass = isHero
+    ? 'animate-spin rounded-full h-14 w-14 border-4 border-sky-400 border-t-transparent mb-4'
+    : 'animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent mb-4'
+
+  const loadingTitleClass = isHero
+    ? 'text-lg font-medium text-slate-100'
+    : 'text-gray-600 dark:text-gray-300 font-medium'
+
+  const loadingSubtitleClass = isHero
+    ? 'mt-2 text-sm text-slate-200/70 text-center px-6'
+    : 'text-sm text-gray-500 dark:text-gray-400 mt-2 text-center px-4'
+
+  const errorFrameClass = isHero
+    ? 'relative aspect-[3/4] sm:aspect-[4/5] lg:aspect-[5/6] overflow-hidden rounded-3xl border border-rose-400/50 bg-gradient-to-br from-rose-500/15 via-rose-500/5 to-rose-500/15 shadow-[0_35px_120px_-45px_rgba(244,114,182,0.6)] backdrop-blur-2xl'
+    : 'relative aspect-square overflow-hidden rounded-lg border-2 border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20'
+
+  const errorIconClass = isHero ? 'text-rose-200 mb-4' : 'text-red-500 dark:text-red-400 mb-4'
+  const errorTitleClass = isHero ? 'text-lg font-semibold text-rose-50 mb-2' : 'text-lg font-medium text-red-800 dark:text-red-200 mb-2'
+  const errorMessageClass = isHero ? 'text-sm text-rose-100/80 text-center mb-4 px-6' : 'text-red-700 dark:text-red-300 text-center mb-4'
+  const errorButtonClass = isHero
+    ? 'px-4 py-2 rounded-lg border border-rose-300/60 bg-rose-500/10 text-sm font-medium text-rose-100 transition-colors hover:bg-rose-500/20'
+    : 'px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors'
+
+  const overlayBackgroundClass = isHero
+    ? 'absolute inset-0 bg-gradient-to-br from-slate-900/20 to-slate-900/60'
+    : 'absolute inset-0 bg-gray-100 dark:bg-gray-800'
+
+  const overlayIconWrapperClass = isHero ? 'text-slate-200/70 mb-2' : 'text-gray-400 dark:text-gray-500 mb-2'
+  const overlayTextClass = isHero ? 'text-sm text-slate-200/80' : 'text-sm text-gray-500 dark:text-gray-400'
+
+  const actionOverlayClass = isHero
+    ? 'absolute inset-0 bg-slate-950/0 group-hover:bg-slate-950/60 transition-all duration-300 flex items-center justify-center opacity-0 group-hover:opacity-100'
+    : 'absolute inset-0 bg-black/0 group-hover:bg-black/50 transition-all duration-200 flex items-center justify-center opacity-0 group-hover:opacity-100'
+
+  const downloadButtonClass = isHero
+    ? 'px-4 py-2 rounded-full border border-white/30 bg-white/20 text-sm font-medium text-white backdrop-blur-lg transition-all hover:border-white hover:bg-white/30 flex items-center gap-2'
+    : 'px-3 py-2 bg-white/90 hover:bg-white text-gray-800 rounded-lg transition-colors flex items-center gap-1 text-sm'
+
+  const clearButtonClass = isHero
+    ? 'px-4 py-2 rounded-full border border-rose-300/50 bg-rose-500/20 text-sm font-medium text-rose-100 transition-all hover:bg-rose-500/30 flex items-center gap-2'
+    : 'px-3 py-2 bg-red-600/90 hover:bg-red-600 text-white rounded-lg transition-colors flex items-center gap-1 text-sm'
+
+  const promptInfoClass = isHero
+    ? 'mt-4 rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-slate-100 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(56,189,248,0.6)]'
+    : 'mt-3 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700'
+
+  const promptLabelClass = isHero ? 'font-semibold text-white' : 'font-medium'
+
+  const emptyFrameClass = isHero
+    ? 'relative aspect-[3/4] sm:aspect-[4/5] lg:aspect-[5/6] overflow-hidden rounded-3xl border-2 border-dashed border-white/25 bg-white/5 backdrop-blur-2xl shadow-[0_30px_100px_-45px_rgba(59,130,246,0.5)]'
+    : 'relative aspect-square overflow-hidden rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/50'
+
+  const emptyTitleClass = isHero ? 'text-xl font-semibold text-white mb-2' : 'text-lg font-medium text-gray-700 dark:text-gray-300 mb-2'
+  const emptyDescriptionClass = isHero ? 'text-slate-200/80 text-center max-w-sm' : 'text-gray-500 dark:text-gray-400 text-center'
+
   // Loading State
   if (isLoading) {
     return (
-      <div className="w-full max-w-2xl mx-auto">
-        <div className="aspect-square bg-gray-100 dark:bg-gray-800 rounded-lg border-2 border-gray-300 dark:border-gray-600 overflow-hidden relative">
-          {/* Skeleton Animation */}
-          <div className="absolute inset-0 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 dark:from-gray-700 dark:via-gray-600 dark:to-gray-700 animate-pulse"></div>
-          
+      <div className={containerClassName}>
+        <div className={baseFrameClass}>
+          <div className={loadingBackdropClass}></div>
+
           {/* Loading Content */}
-          <div className="absolute inset-0 flex flex-col items-center justify-center z-10">
-            <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent mb-4"></div>
-            <p className="text-gray-600 dark:text-gray-300 font-medium">Generating your image...</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2 text-center px-4">
-              This may take a few moments
-            </p>
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center">
+            <div className={loadingSpinnerClass}></div>
+            <p className={loadingTitleClass}>Generating your image...</p>
+            <p className={loadingSubtitleClass}>This may take a few moments</p>
           </div>
         </div>
       </div>
@@ -58,21 +131,18 @@ export default function ImageDisplay({
   // Error State
   if (error && !imageUrl) {
     return (
-      <div className="w-full max-w-2xl mx-auto">
-        <div className="aspect-square bg-red-50 dark:bg-red-900/20 rounded-lg border-2 border-red-300 dark:border-red-700 overflow-hidden relative">
-          <div className="absolute inset-0 flex flex-col items-center justify-center p-6">
-            <div className="text-red-500 dark:text-red-400 mb-4">
-              <svg className="w-16 h-16" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+      <div className={containerClassName}>
+        <div className={errorFrameClass}>
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
+            <div className={errorIconClass}>
+              <svg className="h-16 w-16" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1.293-9.293a1 1 0 011.414 0L10 9.586l1.293-1.293a1 1 0 011.414 1.414L11.414 11l1.293 1.293a1 1 0 01-1.414 1.414L10 12.414l-1.293 1.293a1 1 0 01-1.414-1.414L8.586 11l-1.293-1.293a1 1 0 010-1.414z" clipRule="evenodd" />
               </svg>
             </div>
-            <h3 className="text-lg font-medium text-red-800 dark:text-red-200 mb-2">Generation Failed</h3>
-            <p className="text-red-700 dark:text-red-300 text-center mb-4">{error}</p>
+            <h3 className={errorTitleClass}>Generation Failed</h3>
+            <p className={errorMessageClass}>{error}</p>
             {onRetry && (
-              <button
-                onClick={onRetry}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
-              >
+              <button onClick={onRetry} className={errorButtonClass}>
                 Try Again
               </button>
             )}
@@ -85,28 +155,28 @@ export default function ImageDisplay({
   // Generated Image State
   if (imageUrl) {
     return (
-      <div className="w-full max-w-2xl mx-auto">
-        <div className="aspect-square bg-gray-100 dark:bg-gray-800 rounded-lg border-2 border-gray-300 dark:border-gray-600 overflow-hidden relative group">
+      <div className={containerClassName}>
+        <div className={`${baseFrameClass} group`}>
           {/* Image Loading Overlay */}
-          {isImageLoading && (
-            <div className="absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800 z-10">
-              <div className="animate-spin rounded-full h-8 w-8 border-4 border-blue-500 border-t-transparent"></div>
-            </div>
-          )}
+          {isImageLoading && <div className={overlayBackgroundClass}></div>}
 
           {/* Image Error State */}
           {imageError && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-800 z-10">
-              <div className="text-gray-400 dark:text-gray-500 mb-2">
-                <svg className="w-12 h-12" fill="currentColor" viewBox="0 0 20 20">
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center">
+              <div className={overlayIconWrapperClass}>
+                <svg className="h-12 w-12" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
                 </svg>
               </div>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">Failed to load image</p>
+              <p className={overlayTextClass}>Failed to load image</p>
               {onRetry && (
                 <button
                   onClick={onRetry}
-                  className="mt-2 px-3 py-1 bg-gray-600 hover:bg-gray-700 text-white text-sm rounded transition-colors"
+                  className={
+                    isHero
+                      ? 'mt-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-sm text-white transition-colors hover:bg-white/20'
+                      : 'mt-2 px-3 py-1 bg-gray-600 hover:bg-gray-700 text-white text-sm rounded transition-colors'
+                  }
                 >
                   Retry
                 </button>
@@ -129,9 +199,8 @@ export default function ImageDisplay({
 
           {/* Hover Overlay with Actions */}
           {!isImageLoading && !imageError && (
-            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/50 transition-all duration-200 flex items-center justify-center opacity-0 group-hover:opacity-100">
-              <div className="flex gap-2">
-                {/* Download Button */}
+            <div className={actionOverlayClass}>
+              <div className="flex flex-wrap items-center justify-center gap-3">
                 <button
                   onClick={() => {
                     const link = document.createElement('a')
@@ -139,23 +208,18 @@ export default function ImageDisplay({
                     link.download = `nano-banana-${Date.now()}.jpg`
                     link.click()
                   }}
-                  className="px-3 py-2 bg-white/90 hover:bg-white text-gray-800 rounded-lg transition-colors flex items-center gap-1 text-sm"
+                  className={downloadButtonClass}
                   title="Download image"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                   </svg>
                   Download
                 </button>
 
-                {/* Clear Button */}
                 {onClear && (
-                  <button
-                    onClick={onClear}
-                    className="px-3 py-2 bg-red-600/90 hover:bg-red-600 text-white rounded-lg transition-colors flex items-center gap-1 text-sm"
-                    title="Clear image"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <button onClick={onClear} className={clearButtonClass} title="Clear image">
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
                     Clear
@@ -168,9 +232,9 @@ export default function ImageDisplay({
 
         {/* Image Info */}
         {!isImageLoading && !imageError && prompt && (
-          <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-            <p className="text-sm text-gray-600 dark:text-gray-300">
-              <span className="font-medium">Prompt:</span> {prompt}
+          <div className={promptInfoClass}>
+            <p className="text-sm">
+              <span className={promptLabelClass}>Prompt:</span> {prompt}
             </p>
           </div>
         )}
@@ -180,16 +244,16 @@ export default function ImageDisplay({
 
   // Empty State - No Image Yet
   return (
-    <div className="w-full max-w-2xl mx-auto">
-      <div className="aspect-square bg-gray-50 dark:bg-gray-800/50 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 overflow-hidden relative">
-        <div className="absolute inset-0 flex flex-col items-center justify-center p-6">
-          <div className="text-gray-400 dark:text-gray-500 mb-4">
-            <svg className="w-20 h-20" fill="currentColor" viewBox="0 0 20 20">
+    <div className={containerClassName}>
+      <div className={emptyFrameClass}>
+        <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
+          <div className={isHero ? 'text-slate-300 mb-4' : 'text-gray-400 dark:text-gray-500 mb-4'}>
+            <svg className={isHero ? 'h-20 w-20' : 'w-20 h-20'} fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
             </svg>
           </div>
-          <h3 className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-2">Your Generated Image</h3>
-          <p className="text-gray-500 dark:text-gray-400 text-center">
+          <h3 className={emptyTitleClass}>Your Generated Image</h3>
+          <p className={emptyDescriptionClass}>
             Enter a prompt above and click generate to create your AI image
           </p>
         </div>

--- a/src/components/ImageGenerator.tsx
+++ b/src/components/ImageGenerator.tsx
@@ -11,6 +11,51 @@ interface ImageGeneratorProps {
   onLogout: () => Promise<void>
 }
 
+const samplePrompts = [
+  {
+    label: 'Neon city rain',
+    prompt:
+      'Neon cyberpunk street at night with rain-slick reflections, glowing holographic signs, and umbrellas in motion'
+  },
+  {
+    label: 'Astronaut escape',
+    prompt:
+      'An astronaut relaxing in a hammock on a tropical beach at sunset, painted in vibrant watercolor strokes'
+  },
+  {
+    label: 'Cozy reading nook',
+    prompt:
+      'Golden morning light illuminating a cozy reading nook filled with lush plants, vintage books, and a sleeping cat'
+  }
+]
+
+const quickTips = [
+  {
+    title: 'Paint the scene',
+    description: 'Mention mood, lighting, color palette, and art style so the model understands the vibe you want.',
+    accent: 'from-cyan-500/30 via-sky-500/10 to-sky-500/5',
+    icon: '🎨'
+  },
+  {
+    title: 'Tell a story',
+    description: 'Describe an action or moment in time to add depth. Think about who is there, what is happening, and why.',
+    accent: 'from-violet-500/30 via-fuchsia-500/10 to-fuchsia-500/5',
+    icon: '📖'
+  },
+  {
+    title: 'Work quickly',
+    description: 'Press ⌘ + Enter (Mac) or Ctrl + Enter (PC) to generate instantly. Use Retry to refresh with the same idea.',
+    accent: 'from-emerald-500/30 via-emerald-500/10 to-emerald-500/5',
+    icon: '⌨️'
+  }
+]
+
+const highlightPills = [
+  { icon: '⚡', text: 'Live feedback while you generate' },
+  { icon: '🖼️', text: '1024px high-definition output' },
+  { icon: '⬇️', text: 'One-click download & share ready' }
+]
+
 export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) {
   const {
     prompt,
@@ -32,38 +77,92 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
     reset()
   }
 
-  return (
-    <div className="w-full min-h-screen">
-      {/* User Header */}
-      <UserHeader user={user} onLogout={onLogout} />
-      
-      {/* Main Content */}
-      <div className="max-w-6xl mx-auto px-4 pb-12">
-        <div className="space-y-8">
-          {/* Title Section */}
-          <div className="text-center">
-            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2">
-              Create Your AI Image
-            </h2>
-            <p className="text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-              Describe what you want to see, and our AI will generate a unique image for you. 
-              Be creative and specific for the best results!
-            </p>
-          </div>
+  const handleSamplePromptSelect = (value: string) => {
+    clearError()
+    setPrompt(value)
+  }
 
-          {/* Input Section */}
-          <div className="flex justify-center">
+  const shouldShowTips = !generatedImage && !isLoading
+
+  return (
+    <section className="relative isolate overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-24 top-[-10%] h-[480px] w-[480px] rounded-full bg-sky-500/20 blur-3xl" />
+        <div className="absolute bottom-[-30%] right-[-10%] h-[520px] w-[520px] rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-0 h-[320px] bg-gradient-to-t from-slate-950 via-slate-950/80 to-transparent" />
+      </div>
+
+      <UserHeader
+        user={user}
+        onLogout={onLogout}
+        className="relative z-20 mx-auto w-full max-w-7xl px-6 pt-8 lg:px-12"
+      />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-7xl flex-col-reverse items-center gap-12 px-6 pb-20 pt-12 lg:flex-row lg:items-stretch lg:gap-16 lg:px-12">
+        <div className="w-full lg:w-[420px] xl:w-[460px]">
+          <div className="flex h-full flex-col gap-8 text-center lg:text-left">
+            <div className="space-y-5">
+              <span className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-sky-200">
+                AI Canvas
+              </span>
+              <h2 className="text-4xl font-semibold leading-tight text-white sm:text-5xl">
+                Create Your AI Image
+              </h2>
+              <p className="text-base text-slate-200/80">
+                Describe your vision and watch the canvas come alive with color, texture, and light in just a few seconds.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap justify-center gap-3 lg:justify-start">
+              {highlightPills.map((pill) => (
+                <span
+                  key={pill.text}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-medium text-slate-100 backdrop-blur-sm"
+                >
+                  <span className="text-base">{pill.icon}</span>
+                  {pill.text}
+                </span>
+              ))}
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-left shadow-lg backdrop-blur-xl">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">
+                  Prompt inspiration
+                </p>
+                <span className="text-[10px] font-medium text-slate-200/70">Tap to fill the editor</span>
+              </div>
+              <div className="mt-3 grid gap-2">
+                {samplePrompts.map((sample) => (
+                  <button
+                    key={sample.label}
+                    type="button"
+                    onClick={() => handleSamplePromptSelect(sample.prompt)}
+                    className="group rounded-xl border border-white/10 bg-slate-900/40 px-4 py-3 text-left transition hover:border-white/40 hover:bg-slate-900/60"
+                  >
+                    <p className="text-sm font-semibold text-white">{sample.label}</p>
+                    <p className="mt-1 text-xs text-slate-200/80 group-hover:text-slate-100">
+                      {sample.prompt}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
             <TextPromptInput
               value={prompt}
               onChange={setPrompt}
               onSubmit={generateImage}
               isLoading={isLoading}
               error={error}
+              className="mx-0 max-w-none"
             />
           </div>
+        </div>
 
-          {/* Image Display Section */}
-          <div className="flex justify-center">
+        <div className="relative flex w-full flex-1 items-center justify-center">
+          <div className="absolute -inset-10 hidden rounded-[48px] bg-gradient-to-br from-sky-500/20 via-purple-500/10 to-transparent blur-3xl lg:block" />
+          <div className="relative w-full max-w-[620px]">
             <ImageDisplay
               imageUrl={generatedImage}
               isLoading={isLoading}
@@ -71,68 +170,53 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
               prompt={prompt}
               onRetry={handleRetry}
               onClear={handleClear}
+              variant="hero"
             />
+
+            {generatedImage && !isLoading && !error && (
+              <div className="mt-6 flex justify-center lg:justify-end">
+                <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-100 shadow-[0_20px_60px_-30px_rgba(52,211,153,0.65)]">
+                  <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
+                  Image generated successfully!
+                </div>
+              </div>
+            )}
           </div>
-
-          {/* Quick Tips Section */}
-          {!generatedImage && !isLoading && (
-            <div className="max-w-4xl mx-auto">
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <div className="p-4 bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 rounded-lg border border-blue-200 dark:border-blue-800">
-                  <div className="text-blue-600 dark:text-blue-400 mb-2">
-                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM21 5a2 2 0 00-2-2h-4a2 2 0 00-2 2v12a4 4 0 004 4h4a2 2 0 002-2V5z" />
-                    </svg>
-                  </div>
-                  <h3 className="font-medium text-blue-900 dark:text-blue-100 mb-1">Be Descriptive</h3>
-                  <p className="text-sm text-blue-800 dark:text-blue-200">
-                    Include colors, lighting, mood, and style details for better results.
-                  </p>
-                </div>
-
-                <div className="p-4 bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 rounded-lg border border-purple-200 dark:border-purple-800">
-                  <div className="text-purple-600 dark:text-purple-400 mb-2">
-                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-                    </svg>
-                  </div>
-                  <h3 className="font-medium text-purple-900 dark:text-purple-100 mb-1">Try Examples</h3>
-                  <p className="text-sm text-purple-800 dark:text-purple-200">
-&quot;A magical forest with glowing mushrooms and fairy lights at night&quot;
-                  </p>
-                </div>
-
-                <div className="p-4 bg-gradient-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 rounded-lg border border-green-200 dark:border-green-800 md:col-span-2 lg:col-span-1">
-                  <div className="text-green-600 dark:text-green-400 mb-2">
-                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                    </svg>
-                  </div>
-                  <h3 className="font-medium text-green-900 dark:text-green-100 mb-1">Quick Generate</h3>
-                  <p className="text-sm text-green-800 dark:text-green-200">
-                    Use ⌘+Enter (Mac) or Ctrl+Enter (PC) to generate quickly.
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Success Message */}
-          {generatedImage && !isLoading && !error && (
-            <div className="max-w-2xl mx-auto text-center">
-              <div className="inline-flex items-center px-4 py-2 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 rounded-lg border border-green-200 dark:border-green-700">
-                <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                </svg>
-                <span className="text-sm font-medium">Image generated successfully!</span>
-              </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                Hover over the image to download or create a new one with a different prompt.
-              </p>
-            </div>
-          )}
         </div>
       </div>
-    </div>
+
+      {shouldShowTips && (
+        <div className="relative z-10 mx-auto w-full max-w-7xl px-6 pb-16 lg:px-12">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-2xl backdrop-blur-2xl">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-100">Quick guidance</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">
+                  Craft prompts that glow with detail
+                </h3>
+                <p className="mt-2 max-w-2xl text-sm text-slate-200/80">
+                  These tips help the model understand what matters most in your scene. Try combining them with the inspiration prompts above for instant results.
+                </p>
+              </div>
+              <div className="grid w-full gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {quickTips.map((tip) => (
+                  <div
+                    key={tip.title}
+                    className={`rounded-2xl border border-white/10 bg-gradient-to-br ${tip.accent} p-5 text-left shadow-lg backdrop-blur-xl`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-xl">{tip.icon}</span>
+                      <span className="h-2 w-2 rounded-full bg-white/60" />
+                    </div>
+                    <h4 className="mt-4 text-base font-semibold text-white">{tip.title}</h4>
+                    <p className="mt-2 text-sm text-slate-100/80">{tip.description}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
   )
 }

--- a/src/components/TextPromptInput.tsx
+++ b/src/components/TextPromptInput.tsx
@@ -9,6 +9,7 @@ interface TextPromptInputProps {
   isLoading: boolean
   error: string | null
   maxLength?: number
+  className?: string
 }
 
 export default function TextPromptInput({
@@ -17,7 +18,8 @@ export default function TextPromptInput({
   onSubmit,
   isLoading,
   error,
-  maxLength = 500
+  maxLength = 500,
+  className
 }: TextPromptInputProps) {
   const [isFocused, setIsFocused] = useState(false)
 
@@ -40,8 +42,15 @@ export default function TextPromptInput({
   const isNearLimit = characterCount > maxLength * 0.8
   const isOverLimit = characterCount > maxLength
 
+  const containerClassName = [
+    'w-full max-w-2xl mx-auto',
+    className
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="w-full max-w-2xl mx-auto">
+    <div className={containerClassName}>
       {/* Input Section */}
       <div className="relative">
         <textarea

--- a/src/components/UserHeader.tsx
+++ b/src/components/UserHeader.tsx
@@ -6,9 +6,10 @@ import Image from 'next/image'
 interface UserHeaderProps {
   user: User
   onLogout: () => Promise<void>
+  className?: string
 }
 
-export default function UserHeader({ user, onLogout }: UserHeaderProps) {
+export default function UserHeader({ user, onLogout, className }: UserHeaderProps) {
   const handleLogout = async () => {
     try {
       await onLogout()
@@ -17,9 +18,16 @@ export default function UserHeader({ user, onLogout }: UserHeaderProps) {
     }
   }
 
+  const containerClassName = [
+    'w-full max-w-6xl mx-auto mb-8',
+    className
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="w-full max-w-6xl mx-auto mb-8">
-      <div className="flex items-center justify-between p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+    <div className={containerClassName}>
+      <div className="flex items-center justify-between rounded-2xl border border-white/15 bg-white/10 p-4 text-slate-100 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-white/10">
         {/* User Info */}
         <div className="flex items-center gap-3">
           {/* Profile Picture */}
@@ -41,10 +49,10 @@ export default function UserHeader({ user, onLogout }: UserHeaderProps) {
 
           {/* User Details */}
           <div className="min-w-0">
-            <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            <p className="text-sm font-medium text-white truncate">
               Welcome back{user.displayName ? `, ${user.displayName}` : ''}!
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            <p className="text-xs text-slate-200/70 truncate">
               {user.email}
             </p>
           </div>
@@ -53,15 +61,15 @@ export default function UserHeader({ user, onLogout }: UserHeaderProps) {
         {/* Actions */}
         <div className="flex items-center gap-2">
           {/* Account Badge */}
-          <div className="hidden sm:flex items-center px-2 py-1 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-md text-xs font-medium">
-            <div className="w-2 h-2 bg-green-500 rounded-full mr-1"></div>
+          <div className="hidden sm:flex items-center rounded-full border border-emerald-400/40 bg-emerald-400/10 px-3 py-1 text-xs font-medium text-emerald-200">
+            <div className="mr-1 h-2 w-2 animate-pulse rounded-full bg-emerald-300"></div>
             Active
           </div>
 
           {/* Logout Button */}
           <button
             onClick={handleLogout}
-            className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-md transition-colors"
+            className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-200 transition-colors hover:border-red-400/50 hover:bg-red-500/10 hover:text-red-200"
             title="Sign out"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- elevate the authenticated experience with a full-width ImageGenerator hero that features prompt inspiration, highlight pills, and refreshed quick tips
- update the home page flow so signed-in users land directly in the generator while login, features, and Firestore demo remain easy to reach
- refresh ImageDisplay, UserHeader, and TextPromptInput to support the immersive layout with new styling options and hero-ready variants

## Testing
- `npm run lint` *(fails: existing @typescript-eslint warnings in Firebase scaffolding)*

------
https://chatgpt.com/codex/tasks/task_e_68cea04bc9e08332a804db217f763433