### PR TITLE
Add AI-powered prompt inspiration

### DIFF
--- a/src/app/api/prompt-suggestion/route.ts
+++ b/src/app/api/prompt-suggestion/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import { getRandomPromptSuggestion } from '@/lib/promptSuggestions'
+import type { PromptSuggestionResponse } from '@/types'
+
+const DEFAULT_PROMPT_MODEL = process.env.GEMINI_PROMPT_MODEL || 'gemini-1.5-flash'
+
+function sanitizeSuggestion(raw: string | undefined): string {
+  if (!raw) {
+    return ''
+  }
+
+  const firstMeaningfulLine = raw
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => line.replace(/^[*\-\d\.)\s]+/, ''))[0]
+
+  if (!firstMeaningfulLine) {
+    return ''
+  }
+
+  const trimmed = firstMeaningfulLine
+    .replace(/^['"`]+/, '')
+    .replace(/['"`]+$/, '')
+
+  return trimmed.replace(/\s+/g, ' ').trim()
+}
+
+function buildFallbackResponse(warning?: string) {
+  const payload: PromptSuggestionResponse = {
+    prompt: getRandomPromptSuggestion(),
+    source: 'fallback'
+  }
+
+  if (warning) {
+    payload.warning = warning
+  }
+
+  return NextResponse.json(payload)
+}
+
+export async function GET() {
+  const apiKey = process.env.GEMINI_API_KEY
+
+  if (!apiKey) {
+    return buildFallbackResponse('Gemini API key not configured. Showing a curated prompt instead.')
+  }
+
+  try {
+    const genAI = new GoogleGenerativeAI(apiKey)
+    const model = genAI.getGenerativeModel({ model: DEFAULT_PROMPT_MODEL })
+
+    const generationPrompt = [
+      'Create a unique, imaginative text-to-image prompt for an AI art generator.',
+      'Choose a random subject, setting, and art style each time you are asked.',
+      'Describe mood, lighting, and medium in 25-40 words.',
+      'Return only the prompt sentence without numbering, prefixes, or additional commentary.'
+    ].join(' ')
+
+    const result = await model.generateContent(generationPrompt)
+    const suggestion = sanitizeSuggestion(result.response.text())
+
+    if (!suggestion) {
+      throw new Error('Prompt suggestion was empty')
+    }
+
+    const payload: PromptSuggestionResponse = {
+      prompt: suggestion,
+      source: 'gemini'
+    }
+
+    return NextResponse.json(payload)
+  } catch (error) {
+    console.error('Prompt suggestion generation failed:', error)
+    return buildFallbackResponse('Unable to fetch AI suggestion. Using a curated prompt instead.')
+  }
+}

--- a/src/components/ImageGenerator.tsx
+++ b/src/components/ImageGenerator.tsx
@@ -5,6 +5,7 @@ import { useImageGeneration } from '@/hooks/useImageGeneration'
 import TextPromptInput from '@/components/TextPromptInput'
 import ImageDisplay from '@/components/ImageDisplay'
 import UserHeader from '@/components/UserHeader'
+import PromptInspiration from '@/components/PromptInspiration'
 
 interface ImageGeneratorProps {
   user: User
@@ -53,13 +54,16 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
 
           {/* Input Section */}
           <div className="flex justify-center">
-            <TextPromptInput
-              value={prompt}
-              onChange={setPrompt}
-              onSubmit={generateImage}
-              isLoading={isLoading}
-              error={error}
-            />
+            <div className="w-full max-w-3xl space-y-4">
+              <PromptInspiration onUsePrompt={setPrompt} isGenerating={isLoading} />
+              <TextPromptInput
+                value={prompt}
+                onChange={setPrompt}
+                onSubmit={generateImage}
+                isLoading={isLoading}
+                error={error}
+              />
+            </div>
           </div>
 
           {/* Image Display Section */}

--- a/src/components/PromptInspiration.tsx
+++ b/src/components/PromptInspiration.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getRandomPromptSuggestion } from '@/lib/promptSuggestions'
+import type { PromptSuggestionResponse } from '@/types'
+
+interface PromptInspirationProps {
+  onUsePrompt: (prompt: string) => void
+  isGenerating?: boolean
+}
+
+function sanitizePromptText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+export default function PromptInspiration({ onUsePrompt, isGenerating = false }: PromptInspirationProps) {
+  const initialSuggestion = useMemo(() => getRandomPromptSuggestion(), [])
+  const [suggestion, setSuggestion] = useState<string>(initialSuggestion)
+  const [source, setSource] = useState<'gemini' | 'fallback'>('fallback')
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [message, setMessage] = useState<string | null>(null)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const fetchSuggestion = useCallback(async () => {
+    setIsLoading(true)
+    setMessage(null)
+
+    try {
+      const response = await fetch('/api/prompt-suggestion', {
+        method: 'GET',
+        cache: 'no-store'
+      })
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`)
+      }
+
+      const data = (await response.json()) as PromptSuggestionResponse
+      const cleaned = sanitizePromptText(data.prompt)
+
+      if (!cleaned) {
+        throw new Error('Empty prompt received')
+      }
+
+      if (!isMountedRef.current) {
+        return
+      }
+
+      setSuggestion(cleaned)
+      setSource(data.source)
+      setMessage(data.warning ?? null)
+    } catch (error) {
+      console.error('Failed to load prompt inspiration:', error)
+
+      if (!isMountedRef.current) {
+        return
+      }
+
+      const fallbackPrompt = getRandomPromptSuggestion()
+      setSuggestion(fallbackPrompt)
+      setSource('fallback')
+      setMessage('Using a curated prompt while AI suggestions are unavailable.')
+    } finally {
+      if (!isMountedRef.current) {
+        return
+      }
+
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchSuggestion()
+  }, [fetchSuggestion])
+
+  const handleUsePrompt = useCallback(() => {
+    if (!suggestion || isLoading) {
+      return
+    }
+
+    onUsePrompt(suggestion)
+  }, [isLoading, onUsePrompt, suggestion])
+
+  return (
+    <div className="w-full rounded-2xl border border-white/10 bg-white/60 p-5 shadow-lg backdrop-blur-md transition dark:border-white/5 dark:bg-gray-900/50">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full bg-gradient-to-r from-blue-500/20 to-purple-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-blue-700 dark:text-blue-200">
+              Prompt inspiration
+            </span>
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+              {source === 'gemini' ? 'Generated with Gemini' : 'Curated example'}
+            </span>
+          </div>
+
+          <p className="text-base text-gray-900 transition dark:text-gray-100">{suggestion}</p>
+
+          {isLoading && (
+            <p className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+              {source === 'gemini' ? 'Refreshing the idea...' : 'Finding a fresh idea...'}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col items-stretch gap-2 sm:items-end">
+          <button
+            onClick={handleUsePrompt}
+            disabled={isLoading || !suggestion}
+            className={`
+              inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition
+              ${
+                isLoading || !suggestion
+                  ? 'cursor-not-allowed bg-gray-200 text-gray-500 dark:bg-gray-800 dark:text-gray-500'
+                  : 'bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg hover:from-blue-700 hover:to-purple-700 hover:shadow-xl'
+              }
+            `}
+          >
+            Use this prompt
+          </button>
+
+          <button
+            onClick={fetchSuggestion}
+            disabled={isLoading || isGenerating}
+            className={`
+              inline-flex items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium transition
+              ${
+                isLoading || isGenerating
+                  ? 'cursor-not-allowed border-gray-200 bg-white text-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-600'
+                  : 'border-blue-200 bg-white text-blue-600 hover:border-blue-300 hover:text-blue-700 dark:border-blue-900 dark:bg-transparent dark:text-blue-300 dark:hover:border-blue-700 dark:hover:text-blue-200'
+              }
+            `}
+          >
+            {isLoading ? 'Loading...' : 'New idea'}
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <p className="mt-3 text-xs text-amber-600 dark:text-amber-300">{message}</p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/promptSuggestions.ts
+++ b/src/lib/promptSuggestions.ts
@@ -1,0 +1,19 @@
+export const PROMPT_SUGGESTIONS = [
+  'A bioluminescent rainforest at midnight with misty waterfalls and glowing wildlife painted in vibrant watercolor strokes',
+  'An ancient library carved into a mountainside, lit by floating candles and filled with swirling constellations',
+  'A futuristic jazz club on a floating island with neon holographic musicians and Art Deco architecture',
+  'A serene tea ceremony held by robots in a moss-covered Kyoto garden at golden hour',
+  'An underwater metropolis built inside glowing coral domes with manta-ray taxis gliding through the streets',
+  'A steampunk airship market at dawn with merchants selling clockwork creatures beneath billowing copper balloons',
+  'A cozy cottage perched on a giant turtle traveling across a starlit desert with aurora-filled skies',
+  'A retro-futuristic diner on the moon serving cosmic milkshakes under a panoramic view of Earthrise',
+  'A crystalline ice palace orchestra performing for snow spirits during a swirling aurora borealis',
+  'A whimsical botanical laboratory where plants float midair and emit soft pastel light in a dreamy oil painting style'
+] as const
+
+export type PromptSuggestion = (typeof PROMPT_SUGGESTIONS)[number]
+
+export function getRandomPromptSuggestion(): PromptSuggestion {
+  const index = Math.floor(Math.random() * PROMPT_SUGGESTIONS.length)
+  return PROMPT_SUGGESTIONS[index]
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,12 @@ export interface NanoBananaAPI {
   generateImage(prompt: string): Promise<NanoBananaAPIResponse>
 }
 
+export interface PromptSuggestionResponse {
+  prompt: string
+  source: 'gemini' | 'fallback'
+  warning?: string
+}
+
 export interface UseImageGenerationReturn {
   prompt: string
   setPrompt: (prompt: string) => void


### PR DESCRIPTION
## Summary
- add a PromptInspiration component that surfaces a fresh suggestion on load and wires it into the image generator flow
- create a prompt-suggestion API backed by Gemini with graceful fallbacks to curated ideas
- share a typed prompt suggestion helper so both client and server can pull randomized examples

## Testing
- npm run lint *(fails: existing @typescript-eslint "no-explicit-any" violations in legacy Firebase demo files and unused variable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ceaa35a570833287f370f35391f9f7