### PR TITLE
Require Google sign-in with admin approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A modern web application for generating AI images from text prompts, built with 
 ## ✨ Features
 
 ### Current Features
-- 🔥 **Firebase Authentication** - Complete auth system with email/password and Google OAuth
-- 🔑 **Email/Password Auth** - Traditional login and registration
-- 🚀 **Google OAuth** - One-click Google sign-in
+- 🔥 **Firebase Authentication** - Google-only sign-in with an administrator approval workflow
+- 🛡️ **Admin Approval Queue** - Every new Google login is tracked for manual approval before accessing protected tools
+- 🚀 **Google OAuth** - One-click Google sign-in with Firebase
 - 🗄️ **Firestore Database** - Real-time data storage and retrieval
 - 🖼️ **Firebase Storage** - Save Nano Banana images directly to your bucket
 - 🎨 **AI Image Generation** - Generate beautiful images from text prompts
@@ -58,9 +58,10 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 ### 3. Firebase Setup
 
 1. Create a project at [Firebase Console](https://console.firebase.google.com/)
-2. Enable Authentication with Email/Password and Google providers
+2. Enable Authentication with the Google provider (email/password is not used)
 3. Create a Firestore database
-4. Copy your configuration to `.env.local`
+4. (Optional) Create a `userApprovals` collection to track admin decisions
+5. Copy your configuration to `.env.local`
 
 ### 4. Run Development Server
 
@@ -115,7 +116,7 @@ npx playwright test  # Run end-to-end tests
 ## 🎨 Image Generation Workflow
 
 ### User Journey
-1. **Authentication** - Users sign in with email/password or Google
+1. **Authentication** - Users sign in with Google and wait for admin approval
 2. **Prompt Input** - Enter descriptive text for image generation
 3. **Generation** - Click generate to create AI image (connects to nano-banana API)
 4. **Display** - View generated image with loading states and error handling

--- a/WARP.md
+++ b/WARP.md
@@ -126,12 +126,12 @@ src/
 ### Authentication Flow
 1. **Firebase Setup**: Configuration handled via environment variables
 2. **Context Provider**: `AuthContext` manages authentication state globally
-3. **Multiple Auth Methods**: Email/password and Google OAuth supported
+3. **Google SSO with Admin Approval**: All access flows through Google sign-in and an admin approval queue
 4. **Protected Routes**: Authentication state determines UI rendering
 5. **Error Handling**: Graceful degradation when Firebase not configured
 
 ### Firebase Integration Points
-- **Authentication**: Email/password and Google OAuth via Firebase Auth
+- **Authentication**: Google OAuth via Firebase Auth with approval tracking in Firestore
 - **Firestore**: Ready for database integration (demo component included)
 - **Hosting**: Configured for Firebase static hosting deployment
 - **Security Rules**: Firestore rules configuration in place
@@ -146,7 +146,7 @@ src/
 
 ### Firebase Configuration
 - Project ID: `nano-banana-1758360022` (configured in `.firebaserc`)
-- Authentication providers: Email/Password and Google
+- Authentication providers: Google (email/password disabled)
 - Firestore database ready for integration
 - Hosting configured for static deployment
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,13 +6,14 @@ import ImageGenerator from '@/components/ImageGenerator'
 import FirestoreDemo from '@/components/FirestoreDemo'
 import UserProfile from '@/components/UserProfile'
 import NanoBananaImageUploader from '@/components/NanoBananaImageUploader'
+import PendingApprovalNotice from '@/components/PendingApprovalNotice'
 
 const features = [
   {
     icon: '🔐',
     title: 'Authentication Flows',
     description:
-      'Email/password accounts with Google sign-in ready to wire up so you can focus on your product onboarding.',
+      'Google sign-in with admin approvals keeps the canvas secure without managing local passwords or accounts.',
   },
   {
     icon: '🎨',
@@ -34,34 +35,18 @@ const features = [
   },
 ]
 
-const statusItems = [
-  {
-    label: 'Authentication',
-    detail: 'Connected',
-  },
-  {
-    label: 'Firestore',
-    detail: 'Synced',
-  },
-  {
-    label: 'AI Generation',
-    detail: 'Ready',
-  },
-  {
-    label: 'Hosting',
-    detail: 'Ready to deploy',
-  },
-]
-
 export default function Home() {
-  const { user, loading, logout } = useAuth()
+  const { user, loading, logout, approvalStatus, approvalLoading } = useAuth()
 
-  if (loading) {
+  const isApproved = Boolean(user && approvalStatus === 'approved')
+  const awaitingApproval = Boolean(user && approvalStatus !== 'approved')
+
+  if (loading || approvalLoading) {
     return (
       <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600 dark:text-gray-300">Loading...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4" />
+          <p className="text-gray-600 dark:text-gray-300">Checking your access…</p>
         </div>
       </main>
     )
@@ -69,8 +54,33 @@ export default function Home() {
 
   const wrapperClassName = [
     'relative mx-auto flex max-w-6xl flex-col px-6 pb-24 lg:px-12',
-    user ? 'pt-16' : 'pt-24'
+    isApproved ? 'pt-16' : 'pt-24'
   ].join(' ')
+
+  const statusItems = [
+    {
+      label: 'Authentication',
+      detail: approvalLoading
+        ? 'Verifying…'
+        : isApproved
+          ? 'Approved'
+          : user
+            ? 'Awaiting approval'
+            : 'Google sign-in ready',
+    },
+    {
+      label: 'Firestore',
+      detail: isApproved ? 'Synced' : 'Requires approval',
+    },
+    {
+      label: 'AI Generation',
+      detail: isApproved ? 'Ready' : 'Locked',
+    },
+    {
+      label: 'Hosting',
+      detail: 'Ready to deploy',
+    },
+  ]
 
   return (
     <main className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
@@ -80,7 +90,7 @@ export default function Home() {
         <div className="absolute -bottom-24 right-0 h-[420px] w-[420px] rounded-full bg-purple-500/20 blur-3xl" />
       </div>
 
-      {user && <ImageGenerator user={user} onLogout={logout} />}
+      {isApproved && user && <ImageGenerator user={user} onLogout={logout} />}
 
       <div className={wrapperClassName}>
         {!user && (
@@ -92,14 +102,14 @@ export default function Home() {
               Bring your ideas to life with the Nano Banana AI canvas
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-300 sm:text-xl">
-              Sign in to describe your dream scene and watch the generator fill the screen with rich, download-ready artwork in seconds.
+              Sign in with Google to describe your dream scene and watch the generator fill the screen with rich, download-ready artwork in seconds.
             </p>
             <div className="mt-10 flex flex-wrap justify-center gap-4">
               <a
                 href="#auth"
                 className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-500/40"
               >
-                Sign in to generate
+                Request access
               </a>
               <a
                 href="#features"
@@ -113,7 +123,7 @@ export default function Home() {
 
         <section
           id="features"
-          className={`${user ? 'mt-16' : 'mt-20'} grid gap-6 sm:grid-cols-2 xl:grid-cols-4`}
+          className={`${isApproved ? 'mt-16' : 'mt-20'} grid gap-6 sm:grid-cols-2 xl:grid-cols-4`}
         >
           {features.map((feature) => (
             <article
@@ -134,6 +144,10 @@ export default function Home() {
           {!user ? (
             <div className="mx-auto max-w-2xl">
               <LoginForm />
+            </div>
+          ) : awaitingApproval ? (
+            <div className="mx-auto max-w-3xl">
+              <PendingApprovalNotice />
             </div>
           ) : (
             <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
@@ -158,7 +172,7 @@ export default function Home() {
                 Powerful building blocks for your AI-powered app
               </h2>
               <p className="mx-auto mt-4 max-w-2xl text-base text-slate-300">
-                Secure authentication flows, AI image generation, and Firestore data storage with instant feedback. Everything is wired for rapid iteration and beautiful user experiences.
+                Secure Google authentication, admin-reviewed access, AI image generation, and Firestore data storage with instant feedback. Everything is wired for rapid iteration and beautiful user experiences.
               </p>
               <dl className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-2 max-w-3xl mx-auto">
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-200">
@@ -198,7 +212,6 @@ export default function Home() {
             </div>
           </div>
         </section>
-
       </div>
     </main>
   )

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -4,49 +4,20 @@ import { useState } from 'react'
 import { useAuth } from '@/context/AuthContext'
 
 export default function LoginForm() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [isLogin, setIsLogin] = useState(true)
   const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
-
-  const { login, signup, loginWithGoogle } = useAuth()
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!email || !password) {
-      setError('Please fill in all fields')
-      return
-    }
-
-    try {
-      setError('')
-      setLoading(true)
-
-      if (isLogin) {
-        await login(email, password)
-      } else {
-        await signup(email, password)
-      }
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : 'An unexpected error occurred'
-      setError(message)
-    } finally {
-      setLoading(false)
-    }
-  }
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const { loginWithGoogle } = useAuth()
 
   const handleGoogleLogin = async () => {
     try {
       setError('')
-      setLoading(true)
+      setIsSubmitting(true)
       await loginWithGoogle()
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'An unexpected error occurred'
       setError(message)
     } finally {
-      setLoading(false)
+      setIsSubmitting(false)
     }
   }
 
@@ -55,9 +26,11 @@ export default function LoginForm() {
       <div className="pointer-events-none absolute -top-20 right-0 h-40 w-40 rounded-full bg-sky-500/20 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-24 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-indigo-500/20 blur-3xl" />
 
-      <h2 className="relative text-2xl font-semibold text-center text-white">
-        {isLogin ? 'Login' : 'Sign Up'}
-      </h2>
+      <h2 className="relative text-2xl font-semibold text-center text-white">Sign in with Google</h2>
+
+      <p className="mt-3 text-sm text-center text-slate-300">
+        Sign in with your Google account to request access. An administrator must approve your account before you can generate images or store content.
+      </p>
 
       {error && (
         <div className="relative mt-4 rounded-2xl border border-rose-400/40 bg-rose-500/10 p-3 text-sm text-rose-100">
@@ -65,78 +38,25 @@ export default function LoginForm() {
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="relative mt-6 space-y-4">
-        <div>
-          <label htmlFor="email" className="block text-sm font-medium text-slate-200">
-            Email
-          </label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="mt-1 w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-400"
-            required
-          />
-        </div>
+      <button
+        onClick={handleGoogleLogin}
+        disabled={isSubmitting}
+        className="relative mt-6 flex w-full items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400 disabled:opacity-50"
+      >
+        <svg className="h-5 w-5" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+          <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+          <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+          <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+        </svg>
+        {isSubmitting ? 'Signing in…' : 'Continue with Google'}
+      </button>
 
-        <div>
-          <label htmlFor="password" className="block text-sm font-medium text-slate-200">
-            Password
-          </label>
-          <input
-            type="password"
-            id="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-400"
-            required
-          />
-        </div>
-
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:shadow-xl hover:shadow-sky-500/40 disabled:opacity-50"
-        >
-          {loading ? 'Loading...' : (isLogin ? 'Login' : 'Sign Up')}
-        </button>
-      </form>
-
-      <div className="relative mt-6">
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-white/10"></div>
-          </div>
-          <div className="relative flex justify-center text-sm">
-            <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200">
-              Or continue with
-            </span>
-          </div>
-        </div>
-
-        <button
-          onClick={handleGoogleLogin}
-          disabled={loading}
-          className="mt-4 flex w-full items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm font-medium text-slate-100 transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400 disabled:opacity-50"
-        >
-          <svg className="h-5 w-5" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-            <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-            <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-            <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-          </svg>
-          {loading ? 'Loading...' : 'Continue with Google'}
-        </button>
-      </div>
-
-      <div className="relative mt-6 text-center">
-        <button
-          onClick={() => setIsLogin(!isLogin)}
-          className="text-sm font-medium text-sky-200 transition hover:text-white"
-        >
-          {isLogin ? 'Need an account? Sign up' : 'Already have an account? Login'}
-        </button>
+      <div className="relative mt-6 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+        <p className="font-semibold uppercase tracking-[0.3em] text-sky-100">Admin approval required</p>
+        <p className="mt-2 text-slate-300">
+          After signing in, your request will be sent to the admin team. You will gain full access as soon as your account is approved.
+        </p>
       </div>
     </div>
   )

--- a/src/components/NanoBananaImageUploader.tsx
+++ b/src/components/NanoBananaImageUploader.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FormEvent, useState } from 'react'
+import Image from 'next/image'
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { useAuth } from '@/context/AuthContext'
@@ -24,14 +25,16 @@ const decodeBase64ToUint8Array = (base64Data: string): Uint8Array => {
 }
 
 export default function NanoBananaImageUploader(): JSX.Element | null {
-  const { user } = useAuth()
+  const { user, approvalStatus } = useAuth()
   const [imageUrl, setImageUrl] = useState('')
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState('')
   const [storagePath, setStoragePath] = useState('')
   const [downloadUrl, setDownloadUrl] = useState('')
 
-  if (!user) {
+  const hasApproval = user && approvalStatus === 'approved'
+
+  if (!user || !hasApproval) {
     return null
   }
 
@@ -40,6 +43,11 @@ export default function NanoBananaImageUploader(): JSX.Element | null {
 
     if (!imageUrl.trim()) {
       setError('Please provide the Nano Banana image URL before uploading.')
+      return
+    }
+
+    if (!storage) {
+      setError('Firebase Storage is not configured. Please contact the administrator.')
       return
     }
 
@@ -142,9 +150,12 @@ export default function NanoBananaImageUploader(): JSX.Element | null {
           </a>
           {downloadUrl && (
             <div className="mt-4">
-              <img
+              <Image
                 src={downloadUrl}
                 alt="Stored Nano Banana preview"
+                width={512}
+                height={512}
+                sizes="(max-width: 768px) 100vw, 512px"
                 className="max-h-64 w-full object-contain rounded-md border border-gray-200 dark:border-gray-700"
               />
             </div>

--- a/src/components/PendingApprovalNotice.tsx
+++ b/src/components/PendingApprovalNotice.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Timestamp } from 'firebase/firestore'
+import { useAuth } from '@/context/AuthContext'
+
+const formatTimestamp = (value?: Timestamp | null) => {
+  if (!value) return 'Not recorded yet'
+
+  try {
+    return value.toDate().toLocaleString()
+  } catch (error) {
+    console.warn('Unable to format timestamp', error)
+    return 'Not recorded yet'
+  }
+}
+
+export default function PendingApprovalNotice() {
+  const { user, approvalStatus, approvalLoading, approvalRecord, approvalError, refreshApprovalStatus, logout } = useAuth()
+
+  const statusDescription = useMemo(() => {
+    if (approvalStatus === 'rejected') {
+      return 'Your access request was rejected. Contact the administrator if you believe this is a mistake.'
+    }
+
+    return 'Thanks for signing in! Your request has been sent to the admin team. You will gain full access once your account is approved.'
+  }, [approvalStatus])
+
+  if (!user) {
+    return null
+  }
+
+  const statusLabel = approvalStatus === 'rejected' ? 'Access denied' : 'Awaiting admin approval'
+  const statusTone = approvalStatus === 'rejected'
+    ? 'border-rose-400/40 bg-rose-500/10 text-rose-100'
+    : 'border-amber-400/40 bg-amber-500/10 text-amber-100'
+
+  const canRefresh = approvalStatus !== 'rejected'
+
+  const handleRefresh = async () => {
+    if (canRefresh) {
+      await refreshApprovalStatus()
+    }
+  }
+
+  const handleLogout = async () => {
+    await logout()
+  }
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 text-slate-100 shadow-xl backdrop-blur-xl">
+      <div className="pointer-events-none absolute -top-20 right-10 h-40 w-40 rounded-full bg-amber-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 left-1/3 h-48 w-48 rounded-full bg-sky-500/20 blur-3xl" />
+
+      <div className="relative space-y-6">
+        <span className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] ${statusTone}`}>
+          <span className="h-2 w-2 rounded-full bg-current" />
+          {statusLabel}
+        </span>
+
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Access pending</h2>
+          <p className="mt-2 text-sm text-slate-200/80">{statusDescription}</p>
+        </div>
+
+        {approvalError && (
+          <div className="rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-100">
+            {approvalError}
+          </div>
+        )}
+
+        <dl className="grid gap-4 text-sm text-slate-200 sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Signed in as</dt>
+            <dd className="mt-2 text-sm text-slate-100">{user.email || 'Unknown email'}</dd>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Request submitted</dt>
+            <dd className="mt-2 text-sm text-slate-100">{formatTimestamp(approvalRecord?.requestedAt)}</dd>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Latest update</dt>
+            <dd className="mt-2 text-sm text-slate-100">{formatTimestamp(approvalRecord?.updatedAt)}</dd>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/40 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Status</dt>
+            <dd className="mt-2 text-sm capitalize text-slate-100">{approvalStatus}</dd>
+          </div>
+        </dl>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={!canRefresh || approvalLoading}
+            className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/30 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {approvalLoading ? 'Checking…' : 'Check for approval'}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex-1 rounded-full border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/20 hover:bg-white/10"
+          >
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Timestamp } from 'firebase/firestore'
 import { useAuth } from '@/context/AuthContext'
 
 const providerLabels: Record<string, string> = {
@@ -30,8 +31,21 @@ const formatUid = (uid: string) => {
   return `${uid.slice(0, 6)}…${uid.slice(-4)}`
 }
 
+const formatTimestamp = (value?: Timestamp | null) => {
+  if (!value) return 'Pending'
+
+  const date = value.toDate()
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}
+
 export default function UserProfile() {
-  const { user } = useAuth()
+  const { user, approvalStatus, approvalRecord } = useAuth()
 
   if (!user) return null
 
@@ -39,12 +53,25 @@ export default function UserProfile() {
     ?.map((profile) => providerLabels[profile.providerId] || profile.providerId)
     .filter(Boolean)
     .join(', ')
-    || 'Email & Password'
+    || 'Google'
 
   const accountCreated = formatDate(user.metadata?.creationTime)
   const lastLogin = formatDate(user.metadata?.lastSignInTime)
   const sessionId = formatUid(user.uid)
   const verificationCopy = user.emailVerified ? 'Email verified' : 'Verification pending'
+
+  const approvalCopy =
+    approvalStatus === 'approved'
+      ? 'Admin approved'
+      : approvalStatus === 'rejected'
+        ? 'Approval rejected'
+        : 'Waiting for admin approval'
+
+  const approvalTone = (() => {
+    if (approvalStatus === 'approved') return 'border border-emerald-400/30 bg-emerald-400/10 text-emerald-200'
+    if (approvalStatus === 'rejected') return 'border border-rose-400/30 bg-rose-500/10 text-rose-100'
+    return 'border border-amber-400/30 bg-amber-400/10 text-amber-200'
+  })()
 
   return (
     <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 text-slate-100 shadow-xl backdrop-blur-xl">
@@ -55,9 +82,9 @@ export default function UserProfile() {
         <span className="inline-flex items-center rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-sky-100">
           Account overview
         </span>
-        <h2 className="mt-4 text-2xl font-semibold text-white">You&rsquo;re all set</h2>
+        <h2 className="mt-4 text-2xl font-semibold text-white">Your access summary</h2>
         <p className="mt-2 text-sm text-slate-200/80">
-          Here&rsquo;s a quick snapshot of your session so you can focus on creating stunning art.
+          Here&rsquo;s a quick snapshot of your session and approval status so you can plan your next masterpiece.
         </p>
 
         <dl className="mt-8 grid gap-4 text-sm text-slate-200 sm:grid-cols-2">
@@ -83,6 +110,11 @@ export default function UserProfile() {
         </dl>
 
         <div className="mt-8 flex flex-wrap items-center gap-3">
+          <div className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] ${approvalTone}`}>
+            <span className="h-2 w-2 rounded-full bg-current" />
+            {approvalCopy}
+          </div>
+
           <div className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] ${user.emailVerified ? 'border border-emerald-400/30 bg-emerald-400/10 text-emerald-200' : 'border border-amber-400/30 bg-amber-400/10 text-amber-200'}`}>
             <span className="h-2 w-2 rounded-full bg-current" />
             {verificationCopy}
@@ -96,13 +128,32 @@ export default function UserProfile() {
           )}
         </div>
 
-        <div className="mt-10 rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/60 via-slate-900/30 to-transparent p-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Pro tips</p>
-          <ul className="mt-3 space-y-3 text-sm text-slate-200/80">
-            <li>Mix descriptive lighting, textures, and emotions into prompts for ultra-vivid renders.</li>
-            <li>Save standout prompts locally so you can reuse them after signing back in.</li>
-            <li>Experiment with the Firestore demo beside you to persist prompt ideas in real time.</li>
-          </ul>
+        <div className="mt-10 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/60 via-slate-900/30 to-transparent p-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Approval timeline</p>
+            <ul className="mt-3 space-y-3 text-sm text-slate-200/80">
+              <li>
+                <span className="text-slate-100">Requested:</span> {formatTimestamp(approvalRecord?.requestedAt)}
+              </li>
+              <li>
+                <span className="text-slate-100">Last updated:</span> {formatTimestamp(approvalRecord?.updatedAt)}
+              </li>
+              {approvalRecord?.approvedBy && (
+                <li>
+                  <span className="text-slate-100">Approved by:</span> {approvalRecord.approvedBy}
+                </li>
+              )}
+            </ul>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/60 via-slate-900/30 to-transparent p-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">Pro tips</p>
+            <ul className="mt-3 space-y-3 text-sm text-slate-200/80">
+              <li>Mix descriptive lighting, textures, and emotions into prompts for ultra-vivid renders.</li>
+              <li>Save standout prompts locally so you can reuse them after signing back in.</li>
+              <li>Experiment with the Firestore demo beside you to persist prompt ideas in real time.</li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,16 +1,33 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState } from 'react'
-import { User, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, signInWithPopup } from 'firebase/auth'
-import { auth, googleProvider } from '@/lib/firebase'
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { User, onAuthStateChanged, signInWithPopup, signOut } from 'firebase/auth'
+import { Timestamp, doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore'
+import { auth, db, googleProvider } from '@/lib/firebase'
+
+type UserApprovalState = 'pending' | 'approved' | 'rejected'
+export type ApprovalStatus = UserApprovalState | 'unknown'
+
+export interface UserApprovalRecord {
+  status: UserApprovalState
+  email: string | null
+  displayName: string | null
+  requestedAt: Timestamp | null
+  updatedAt: Timestamp | null
+  approvedBy: string | null
+  approvedAt: Timestamp | null
+}
 
 interface AuthContextType {
   user: User | null
   loading: boolean
-  signup: (email: string, password: string) => Promise<void>
-  login: (email: string, password: string) => Promise<void>
   loginWithGoogle: () => Promise<void>
   logout: () => Promise<void>
+  approvalStatus: ApprovalStatus
+  approvalLoading: boolean
+  approvalError: string | null
+  approvalRecord: UserApprovalRecord | null
+  refreshApprovalStatus: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType>({} as AuthContextType)
@@ -22,17 +39,10 @@ export const useAuth = () => {
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  const signup = async (email: string, password: string) => {
-    if (!auth) throw new Error('Firebase Auth not initialized')
-    await createUserWithEmailAndPassword(auth, email, password)
-  }
-
-  const login = async (email: string, password: string) => {
-    if (!auth) throw new Error('Firebase Auth not initialized')
-    await signInWithEmailAndPassword(auth, email, password)
-  }
+  const [approvalStatus, setApprovalStatus] = useState<ApprovalStatus>('unknown')
+  const [approvalLoading, setApprovalLoading] = useState(false)
+  const [approvalError, setApprovalError] = useState<string | null>(null)
+  const [approvalRecord, setApprovalRecord] = useState<UserApprovalRecord | null>(null)
 
   const loginWithGoogle = async () => {
     if (!auth || !googleProvider) throw new Error('Firebase Auth not initialized')
@@ -42,42 +52,127 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const logout = async () => {
     if (!auth) throw new Error('Firebase Auth not initialized')
     await signOut(auth)
+    setApprovalStatus('unknown')
+    setApprovalRecord(null)
+    setApprovalError(null)
   }
+
+  const updateApprovalState = useCallback(async (currentUser: User | null) => {
+    if (!currentUser) {
+      setApprovalStatus('unknown')
+      setApprovalRecord(null)
+      setApprovalError(null)
+      setApprovalLoading(false)
+      return
+    }
+
+    if (!db) {
+      setApprovalStatus('pending')
+      setApprovalRecord(null)
+      setApprovalError('Firestore is not configured. Unable to verify admin approval.')
+      setApprovalLoading(false)
+      return
+    }
+
+    setApprovalLoading(true)
+    setApprovalError(null)
+
+    try {
+      const approvalRef = doc(db, 'userApprovals', currentUser.uid)
+      const snapshot = await getDoc(approvalRef)
+
+      if (!snapshot.exists()) {
+        const now = Timestamp.now()
+        await setDoc(approvalRef, {
+          status: 'pending',
+          email: currentUser.email ?? null,
+          displayName: currentUser.displayName ?? null,
+          requestedAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+
+        setApprovalStatus('pending')
+        setApprovalRecord({
+          status: 'pending',
+          email: currentUser.email ?? null,
+          displayName: currentUser.displayName ?? null,
+          requestedAt: now,
+          updatedAt: now,
+          approvedBy: null,
+          approvedAt: null,
+        })
+        return
+      }
+
+      const data = snapshot.data() as Partial<UserApprovalRecord & { status: UserApprovalState }>
+      const status: UserApprovalState = data.status ?? 'pending'
+
+      setApprovalStatus(status)
+      setApprovalRecord({
+        status,
+        email: data.email ?? currentUser.email ?? null,
+        displayName: data.displayName ?? currentUser.displayName ?? null,
+        requestedAt: (data.requestedAt as Timestamp | undefined) ?? null,
+        updatedAt: (data.updatedAt as Timestamp | undefined) ?? null,
+        approvedBy: (data.approvedBy as string | undefined) ?? null,
+        approvedAt: (data.approvedAt as Timestamp | undefined) ?? null,
+      })
+    } catch (error) {
+      console.error('Failed to fetch approval status:', error)
+      setApprovalError('Unable to verify admin approval. Please try again later.')
+      setApprovalStatus('pending')
+    } finally {
+      setApprovalLoading(false)
+    }
+  }, [])
+
+  const refreshApprovalStatus = useCallback(async () => {
+    await updateApprovalState(user)
+  }, [updateApprovalState, user])
 
   useEffect(() => {
     if (!auth) {
       console.warn('Firebase Auth not initialized - running without authentication')
       setLoading(false)
-      setError('Firebase Auth not available')
       return
     }
 
     try {
-      const unsubscribe = onAuthStateChanged(auth, (user) => {
-        setUser(user)
-        setLoading(false)
-        setError(null)
-      }, (error) => {
-        console.warn('Firebase Auth not configured yet:', error.message)
-        setError('Firebase Auth not configured')
-        setLoading(false)
-      })
+      const unsubscribe = onAuthStateChanged(
+        auth,
+        (currentUser) => {
+          setLoading(true)
+          setUser(currentUser)
+          updateApprovalState(currentUser).finally(() => {
+            setLoading(false)
+          })
+        },
+        (authError) => {
+          console.warn('Firebase Auth not configured yet:', authError.message)
+          setApprovalError('Firebase Auth not configured')
+          setLoading(false)
+        }
+      )
 
       return unsubscribe
-    } catch (error: any) {
-      console.warn('Firebase Auth initialization error:', error.message)
-      setError('Firebase Auth not available')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      console.warn('Firebase Auth initialization error:', message)
+      setApprovalError('Firebase Auth not available')
       setLoading(false)
     }
-  }, [])
+  }, [updateApprovalState])
 
   const value = {
     user,
     loading,
-    signup,
-    login,
     loginWithGoogle,
     logout,
+    approvalStatus,
+    approvalLoading,
+    approvalError,
+    approvalRecord,
+    refreshApprovalStatus,
   }
 
   return (

--- a/src/hooks/useImageGeneration.ts
+++ b/src/hooks/useImageGeneration.ts
@@ -37,8 +37,8 @@ export function useImageGeneration(): UseImageGenerationReturn {
       const response = await nanoBananaAPI.generateImage(prompt)
       setGeneratedImage(response.imageUrl)
 
-      // Auto-save to Firebase Storage if user is logged in
-      if (user && response.imageUrl) {
+      // Auto-save to Firebase Storage if user is logged in and storage is available
+      if (user && response.imageUrl && storage) {
         try {
           console.log('Auto-saving image to Firebase Storage...')
 
@@ -77,6 +77,8 @@ export function useImageGeneration(): UseImageGenerationReturn {
           console.error('Auto-save to Firebase Storage failed:', saveError)
           // Don't show error to user for auto-save failures
         }
+      } else if (!storage) {
+        console.warn('Firebase Storage not initialized. Skipping auto-save.')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate image')

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp, getApps } from 'firebase/app'
-import { getAuth, GoogleAuthProvider } from 'firebase/auth'
-import { getFirestore } from 'firebase/firestore'
-import { getStorage } from 'firebase/storage'
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app'
+import { getAuth, GoogleAuthProvider, type Auth } from 'firebase/auth'
+import { getFirestore, type Firestore } from 'firebase/firestore'
+import { getStorage, type FirebaseStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,28 +13,33 @@ const firebaseConfig = {
 }
 
 // Initialize Firebase
-let firebase_app: any = null
-let auth: any = null
-let db: any = null
-let googleProvider: any = null
+let firebaseApp: FirebaseApp | null = null
+let authInstance: Auth | null = null
+let dbInstance: Firestore | null = null
+let googleAuthProvider: GoogleAuthProvider | null = null
+let storageInstance: FirebaseStorage | null = null
 
 try {
-  firebase_app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0]
+  firebaseApp = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0]
 
   // Initialize Firebase Auth and get a reference to the service
-  auth = getAuth(firebase_app)
+  authInstance = getAuth(firebaseApp)
 
   // Initialize Firebase Firestore and get a reference to the service
-  db = getFirestore(firebase_app)
+  dbInstance = getFirestore(firebaseApp)
 
   // Initialize Google Auth Provider
-  googleProvider = new GoogleAuthProvider()
+  googleAuthProvider = new GoogleAuthProvider()
+
+  // Initialize Firebase Storage and get a reference to the service
+  storageInstance = getStorage(firebaseApp)
 } catch (error) {
   console.warn('Firebase initialization failed:', error)
 }
 
-// Initialize Firebase Storage and get a reference to the service
-export const storage = getStorage(firebase_app)
+export const auth = authInstance
+export const db = dbInstance
+export const googleProvider = googleAuthProvider
+export const storage = storageInstance
 
-export { auth, db, googleProvider }
-export default firebase_app
+export default firebaseApp

--- a/src/lib/nanoBananaAPI.ts
+++ b/src/lib/nanoBananaAPI.ts
@@ -3,18 +3,18 @@ import { NanoBananaAPI, NanoBananaAPIResponse } from '@/types'
 // Mock implementation for development
 // This will be replaced with actual API integration later
 class MockNanoBananaAPI implements NanoBananaAPI {
-  async generateImage(_prompt: string): Promise<NanoBananaAPIResponse> {
+  async generateImage(prompt: string): Promise<NanoBananaAPIResponse> {
     // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 2000 + Math.random() * 3000))
-    
+
     // Simulate occasional errors for testing
     if (Math.random() < 0.1) {
       throw new Error('Failed to generate image. Please try again.')
     }
-    
+
     // Return mock data with placeholder image
     const mockImageId = Math.random().toString(36).substring(7)
-    
+
     return {
       imageUrl: `https://picsum.photos/512/512?random=${mockImageId}`,
       id: mockImageId,
@@ -24,7 +24,8 @@ class MockNanoBananaAPI implements NanoBananaAPI {
           width: 512,
           height: 512
         },
-        generatedAt: new Date()
+        generatedAt: new Date(),
+        prompt,
       }
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export interface ImageMetadata {
     height: number
   }
   generatedAt: Date
+  prompt?: string
 }
 
 export interface ImageGenerationState {


### PR DESCRIPTION
## Summary
- enforce Google-only authentication with admin approval tracking in the auth context and login flow
- gate app experiences behind the new approval status, including pending approval messaging and updated profile details
- harden Firebase usage, storage uploads, and Firestore demo with approval checks and refreshed documentation reflecting the new workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceae5290948332a341ee27b74d2ab6