### PR TITLE
Add Vercel deployment documentation and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 
 # Set to 'true' to use real Gemini API, 'false' or omit to use mock API
 NEXT_PUBLIC_USE_REAL_API=false
+
+# Vercel Deployment Configuration
+# Set to the URL of your deployed Vercel application (optional, used for callbacks)
+NEXT_PUBLIC_APP_URL=https://your-vercel-project-url.vercel.app

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,38 @@
+# Ignore files that should not be uploaded to Vercel
+
+# Environment and secrets
+.env
+.env.*
+*.local
+*.env
+
+# Dependencies
+node_modules
+
+# Build and test artifacts
+coverage
+playwright-report
+playwright/.cache
+.test-results
+/tmp
+
+# Local tooling directories
+.bmad-core
+.cursor
+.taskmaster
+.qoder
+.turbo
+
+# Repository-specific documentation and assets not required at runtime
+agentic-docs
+agents
+quick-check.png
+refresh-test-*.png
+demo-*-state.png
+manual-verification-screenshot.png
+nano-banana-screenshot.png
+login-page-screenshot.png
+main-page-screenshot.png
+debug-page.png
+test-auth-page-screenshot.png
+app-initial-state.png

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install
 cp .env.example .env.local
 ```
 
-Edit `.env.local` with your Firebase credentials:
+Edit `.env.local` with your Firebase credentials and deployment settings:
 
 ```env
 NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key_here
@@ -48,6 +48,9 @@ NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project_id.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+GEMINI_API_KEY=your_gemini_api_key_here
+NEXT_PUBLIC_USE_REAL_API=false
+NEXT_PUBLIC_APP_URL=https://your-vercel-project-url.vercel.app
 ```
 
 ### 3. Firebase Setup
@@ -64,6 +67,18 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to see the app.
+
+## ☁️ Deploy to Vercel
+
+The project ships with a ready-to-use [`vercel.json`](vercel.json) configuration and a curated [deployment guide](docs/deployment/vercel.md).
+
+1. [Create or log in to a Vercel account](https://vercel.com/).
+2. Import this repository from your Git provider. Vercel will auto-detect the Next.js framework and suggested build settings.
+3. Add the environment variables from `.env.local` (see table in the deployment guide). Include `NEXT_PUBLIC_APP_URL` with your production domain and enable `NEXT_PUBLIC_USE_REAL_API=true` only when your Gemini API key is active.
+4. Deploy the project. Vercel will provide a preview URL and, once promoted, a production domain.
+5. Optionally deploy via the Vercel CLI (`vercel --prod`) to trigger new builds from your terminal.
+
+> ℹ️ The [`.vercelignore`](.vercelignore) file keeps local tooling assets and large screenshots out of your deployment bundle. Customize it if you need to ship additional static assets.
 
 ## 📁 Project Structure
 

--- a/docs/deployment/vercel.md
+++ b/docs/deployment/vercel.md
@@ -1,0 +1,78 @@
+# Deploying Nano Banana to Vercel
+
+This guide walks you through deploying the **Nano Banana** Next.js application to [Vercel](https://vercel.com). The steps cover everything from collecting environment variables to verifying your production deployment.
+
+## 1. Prerequisites
+
+Before you begin, make sure you have:
+
+- A Vercel account with access to the Git provider that hosts this repository.
+- Node.js 18 or newer installed locally.
+- Firebase project configured with Authentication and Firestore.
+- A Gemini API key from [Google AI Studio](https://aistudio.google.com/) if you plan to enable real image generation.
+
+## 2. Collect Required Environment Variables
+
+Copy `.env.example` to `.env.local` and replace placeholder values with your project secrets. You will provide the same values to Vercel.
+
+| Variable | Required | Description | Source |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | ✅ | Public Firebase web API key | Firebase Console → Project Settings |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | ✅ | Firebase Auth domain (`<project>.firebaseapp.com`) | Firebase Console |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | ✅ | Firebase project identifier | Firebase Console |
+| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | ✅ | Cloud Storage bucket | Firebase Console |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | ✅ | Firebase messaging sender ID | Firebase Console |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | ✅ | Firebase application ID | Firebase Console |
+| `GEMINI_API_KEY` | ⚪️ | Gemini API key for real image generation (optional) | Google AI Studio |
+| `NEXT_PUBLIC_USE_REAL_API` | ⚪️ | Set to `true` to call the real Gemini API | Manual toggle |
+| `NEXT_PUBLIC_APP_URL` | ⚪️ | Public URL of your deployment, useful for callbacks | Vercel → Domains |
+
+> ℹ️ Leave `NEXT_PUBLIC_USE_REAL_API=false` if you are using mock data while the image API is under development.
+
+## 3. Prepare Firebase and Firestore
+
+1. Enable **Authentication** with Email/Password and Google providers.
+2. Create a **Firestore** database in production mode.
+3. Optionally apply the security rules in [`firestore.rules`](../../firestore.rules).
+4. If you need custom indexes, publish [`firestore.indexes.json`](../../firestore.indexes.json) via the Firebase CLI.
+
+## 4. Deploy through the Vercel Dashboard
+
+1. Log in to Vercel and click **New Project**.
+2. Import this Git repository from your Git provider.
+3. When prompted for the framework, Vercel should auto-detect **Next.js**. If not, select it manually.
+4. In the **Environment Variables** section add the variables from step 2. Use the same names exactly as shown.
+5. Leave the default build (`npm run build`) and install (`npm install`) commands unless you need to customize caching.
+6. Click **Deploy**. Vercel will build and host the application at a preview URL.
+7. Assign a production domain (the default `*.vercel.app` subdomain or a custom domain) and update `NEXT_PUBLIC_APP_URL` accordingly.
+
+## 5. (Optional) Deploy with the Vercel CLI
+
+If you prefer deploying from the command line:
+
+```bash
+npm install -g vercel
+vercel login            # Authenticate once
+vercel link             # Link the local project to a Vercel project
+vercel env pull .env.local
+vercel env add          # Add/confirm missing variables interactively
+vercel --prod           # Trigger a production deployment
+```
+
+The `vercel env pull` command keeps your local `.env.local` in sync with the dashboard configuration.
+
+## 6. Post-Deployment Checklist
+
+- Visit the deployed site and confirm authentication flows work.
+- Trigger the image generation flow. If you are using the mock API, confirm that the UI shows placeholder responses.
+- Verify console output for runtime errors using the Vercel dashboard → **Project** → **Functions / Logs**.
+- Configure Firestore indexes and security rules if you have not already.
+- Share the deployment URL with stakeholders and update `NEXT_PUBLIC_APP_URL` for environment-specific logic.
+
+## 7. Troubleshooting Tips
+
+- **Build fails with missing environment variables**: Re-check that every required variable is configured for the `Production` environment in Vercel.
+- **Authentication redirect errors**: Ensure your Firebase OAuth redirect domain matches the deployed Vercel domain.
+- **API 500 errors**: Inspect logs in Vercel and verify that `GEMINI_API_KEY` is valid if you enabled real API calls.
+
+With these steps, your Nano Banana app should be live on Vercel with production-ready settings.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
## Summary
- expand the README with Vercel deployment steps and the full set of environment variables
- add a dedicated deployment guide alongside Vercel configuration and ignore files
- refresh the environment example to cover production settings used on Vercel

## Testing
- npm run lint *(fails: existing lint violations in src components unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9df6e6688332b0f71bfd55fc1def