### PR TITLE
Auto-generate images from curated prompts

### DIFF
--- a/src/components/ImageGenerator.tsx
+++ b/src/components/ImageGenerator.tsx
@@ -71,7 +71,7 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
 
   const handleRetry = () => {
     clearError()
-    generateImage()
+    void generateImage()
   }
 
   const handleClear = () => {
@@ -79,8 +79,21 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
   }
 
   const handleSamplePromptSelect = (value: string) => {
+    if (isLoading) {
+      return
+    }
     clearError()
     setPrompt(value)
+    void generateImage(value)
+  }
+
+  const handlePromptInspirationUse = (value: string) => {
+    if (isLoading) {
+      return
+    }
+    clearError()
+    setPrompt(value)
+    void generateImage(value)
   }
 
   const shouldShowTips = !generatedImage && !isLoading
@@ -126,7 +139,7 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
               ))}
             </div>
 
-            <PromptInspiration onUsePrompt={setPrompt} isGenerating={isLoading} />
+            <PromptInspiration onUsePrompt={handlePromptInspirationUse} isGenerating={isLoading} />
 
             <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-left shadow-lg backdrop-blur-xl">
               <div className="flex items-center justify-between gap-2">

--- a/src/components/TextPromptInput.tsx
+++ b/src/components/TextPromptInput.tsx
@@ -5,7 +5,7 @@ import { useState, KeyboardEvent } from 'react'
 interface TextPromptInputProps {
   value: string
   onChange: (value: string) => void
-  onSubmit: () => void
+  onSubmit: () => void | Promise<void>
   isLoading: boolean
   error: string | null
   maxLength?: number

--- a/src/hooks/useImageGeneration.ts
+++ b/src/hooks/useImageGeneration.ts
@@ -42,83 +42,93 @@ export function useImageGeneration(): UseImageGenerationReturn {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const generateImage = useCallback(async () => {
-    if (!prompt.trim()) {
-      setError('Please enter a prompt to generate an image')
-      return
-    }
+  const generateImage = useCallback(
+    async (promptOverride?: string) => {
+      const promptToUse = promptOverride ?? prompt
+      const sanitizedPrompt = promptToUse.trim()
 
-    if (prompt.length < 3) {
-      setError('Prompt must be at least 3 characters long')
-      return
-    }
-
-    if (prompt.length > 500) {
-      setError('Prompt must be less than 500 characters')
-      return
-    }
-
-    try {
-      setIsLoading(true)
-      setError(null)
-
-      const response = await nanoBananaAPI.generateImage(prompt)
-      setGeneratedImage(response.imageUrl)
-
-      // Auto-save to Firebase Storage if user is logged in
-      if (user && response.imageUrl) {
-        try {
-          console.log('Auto-saving image to Firebase Storage...')
-
-          // Fetch the image data using our API endpoint
-          const apiResponse = await fetch('/api/nano-banana-image', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ imageUrl: response.imageUrl })
-          })
-
-          if (apiResponse.ok) {
-            const { contentType, data } = await apiResponse.json()
-
-            // Convert base64 to Uint8Array
-            const binaryString = atob(data)
-            const bytes = new Uint8Array(binaryString.length)
-            for (let i = 0; i < binaryString.length; i++) {
-              bytes[i] = binaryString.charCodeAt(i)
-            }
-
-            if (!storage) {
-              console.warn('Firebase Storage not available, skipping auto-save')
-              return
-            }
-
-            // Create storage path
-            const now = new Date()
-            const timestamp = now.getTime()
-            const promptSlug = createPromptSlug(prompt)
-            const dateSegment = `${now.getFullYear()}-${formatTwoDigits(now.getMonth() + 1)}-${formatTwoDigits(now.getDate())}`
-            const path = `nano-banana/${user.uid}/${dateSegment}-${promptSlug}-${timestamp}`
-
-            // Upload to Firebase Storage
-            const storageRef = ref(storage, path)
-            await uploadBytes(storageRef, bytes, { contentType })
-
-            const downloadUrl = await getDownloadURL(storageRef)
-            console.log('Image auto-saved to Firebase Storage:', downloadUrl)
-          } else {
-            console.warn('Failed to fetch image for auto-save:', apiResponse.statusText)
-          }
-        } catch (saveError) {
-          console.error('Auto-save to Firebase Storage failed:', saveError)
-          // Don't show error to user for auto-save failures
-        }
+      if (!sanitizedPrompt) {
+        setError('Please enter a prompt to generate an image')
+        return
       }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to generate image')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [prompt, user])
+
+      if (sanitizedPrompt.length < 3) {
+        setError('Prompt must be at least 3 characters long')
+        return
+      }
+
+      if (sanitizedPrompt.length > 500) {
+        setError('Prompt must be less than 500 characters')
+        return
+      }
+
+      try {
+        setIsLoading(true)
+        setError(null)
+
+        if (sanitizedPrompt !== prompt) {
+          setPrompt(sanitizedPrompt)
+        }
+
+        const response = await nanoBananaAPI.generateImage(sanitizedPrompt)
+        setGeneratedImage(response.imageUrl)
+
+        // Auto-save to Firebase Storage if user is logged in
+        if (user && response.imageUrl) {
+          try {
+            console.log('Auto-saving image to Firebase Storage...')
+
+            // Fetch the image data using our API endpoint
+            const apiResponse = await fetch('/api/nano-banana-image', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ imageUrl: response.imageUrl })
+            })
+
+            if (apiResponse.ok) {
+              const { contentType, data } = await apiResponse.json()
+
+              // Convert base64 to Uint8Array
+              const binaryString = atob(data)
+              const bytes = new Uint8Array(binaryString.length)
+              for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i)
+              }
+
+              if (!storage) {
+                console.warn('Firebase Storage not available, skipping auto-save')
+                return
+              }
+
+              // Create storage path
+              const now = new Date()
+              const timestamp = now.getTime()
+              const promptSlug = createPromptSlug(sanitizedPrompt)
+              const dateSegment = `${now.getFullYear()}-${formatTwoDigits(now.getMonth() + 1)}-${formatTwoDigits(now.getDate())}`
+              const path = `nano-banana/${user.uid}/${dateSegment}-${promptSlug}-${timestamp}`
+
+              // Upload to Firebase Storage
+              const storageRef = ref(storage, path)
+              await uploadBytes(storageRef, bytes, { contentType })
+
+              const downloadUrl = await getDownloadURL(storageRef)
+              console.log('Image auto-saved to Firebase Storage:', downloadUrl)
+            } else {
+              console.warn('Failed to fetch image for auto-save:', apiResponse.statusText)
+            }
+          } catch (saveError) {
+            console.error('Auto-save to Firebase Storage failed:', saveError)
+            // Don't show error to user for auto-save failures
+          }
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to generate image')
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [prompt, user]
+  )
 
   const clearError = useCallback(() => {
     setError(null)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,7 +46,7 @@ export interface UseImageGenerationReturn {
   generatedImage: string | null
   isLoading: boolean
   error: string | null
-  generateImage: () => Promise<void>
+  generateImage: (promptOverride?: string) => Promise<void>
   clearError: () => void
   reset: () => void
 }


### PR DESCRIPTION
## Summary
- trigger image generation when a curated or sample prompt is selected so users do not need to re-run manually
- allow the image generation hook to accept an optional prompt override while trimming and reusing the text for storage metadata
- widen the text input submit signature so async generators remain type-safe

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cec13dd19c83328342e6a3c0d80bb7