### PR TITLE
Adjust inspiration layout and tips interactions

### DIFF
--- a/src/components/ImageGenerator.tsx
+++ b/src/components/ImageGenerator.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { User } from 'firebase/auth'
 import { useImageGeneration } from '@/hooks/useImageGeneration'
 import TextPromptInput from '@/components/TextPromptInput'
@@ -11,24 +12,6 @@ interface ImageGeneratorProps {
   user: User
   onLogout: () => Promise<void>
 }
-
-const samplePrompts = [
-  {
-    label: 'Neon city rain',
-    prompt:
-      'Neon cyberpunk street at night with rain-slick reflections, glowing holographic signs, and umbrellas in motion'
-  },
-  {
-    label: 'Astronaut escape',
-    prompt:
-      'An astronaut relaxing in a hammock on a tropical beach at sunset, painted in vibrant watercolor strokes'
-  },
-  {
-    label: 'Cozy reading nook',
-    prompt:
-      'Golden morning light illuminating a cozy reading nook filled with lush plants, vintage books, and a sleeping cat'
-  }
-]
 
 const quickTips = [
   {
@@ -69,6 +52,9 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
     reset
   } = useImageGeneration()
 
+  const [isTipsExpanded, setIsTipsExpanded] = useState(false)
+  const [isTipsHovered, setIsTipsHovered] = useState(false)
+
   const handleRetry = () => {
     clearError()
     void generateImage()
@@ -76,15 +62,6 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
 
   const handleClear = () => {
     reset()
-  }
-
-  const handleSamplePromptSelect = (value: string) => {
-    if (isLoading) {
-      return
-    }
-    clearError()
-    setPrompt(value)
-    void generateImage(value)
   }
 
   const handlePromptInspirationUse = (value: string) => {
@@ -97,6 +74,7 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
   }
 
   const shouldShowTips = !generatedImage && !isLoading
+  const showTipsContent = isTipsExpanded || isTipsHovered
 
   return (
     <section className="relative isolate overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 text-slate-100">
@@ -141,30 +119,6 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
 
             <PromptInspiration onUsePrompt={handlePromptInspirationUse} isGenerating={isLoading} />
 
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-left shadow-lg backdrop-blur-xl">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">
-                  Prompt inspiration
-                </p>
-                <span className="text-[10px] font-medium text-slate-200/70">Tap to fill the editor</span>
-              </div>
-              <div className="mt-3 grid gap-2">
-                {samplePrompts.map((sample) => (
-                  <button
-                    key={sample.label}
-                    type="button"
-                    onClick={() => handleSamplePromptSelect(sample.prompt)}
-                    className="group rounded-xl border border-white/10 bg-slate-900/40 px-4 py-3 text-left transition hover:border-white/40 hover:bg-slate-900/60"
-                  >
-                    <p className="text-sm font-semibold text-white">{sample.label}</p>
-                    <p className="mt-1 text-xs text-slate-200/80 group-hover:text-slate-100">
-                      {sample.prompt}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            </div>
-
             <TextPromptInput
               value={prompt}
               onChange={setPrompt}
@@ -204,32 +158,69 @@ export default function ImageGenerator({ user, onLogout }: ImageGeneratorProps) 
 
       {shouldShowTips && (
         <div className="relative z-10 mx-auto w-full max-w-7xl px-6 pb-16 lg:px-12">
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-2xl backdrop-blur-2xl">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-              <div>
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-100">Quick guidance</p>
-                <h3 className="mt-3 text-2xl font-semibold text-white">
-                  Craft prompts that glow with detail
-                </h3>
-                <p className="mt-2 max-w-2xl text-sm text-slate-200/80">
-                  These tips help the model understand what matters most in your scene. Try combining them with the inspiration prompts above for instant results.
-                </p>
-              </div>
-              <div className="grid w-full gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {quickTips.map((tip) => (
-                  <div
-                    key={tip.title}
-                    className={`rounded-2xl border border-white/10 bg-gradient-to-br ${tip.accent} p-5 text-left shadow-lg backdrop-blur-xl`}
+          <div
+            className="rounded-3xl border border-white/10 bg-white/5 p-6 sm:p-8 shadow-2xl backdrop-blur-2xl transition-all duration-300"
+            onMouseEnter={() => setIsTipsHovered(true)}
+            onMouseLeave={() => setIsTipsHovered(false)}
+          >
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-100">Quick guidance</p>
+                  {!showTipsContent && (
+                    <p className="mt-2 text-xs text-slate-200/70">Hover or select to explore the quick tips.</p>
+                  )}
+                  {showTipsContent && (
+                    <>
+                      <h3 className="mt-3 text-2xl font-semibold text-white">
+                        Craft prompts that glow with detail
+                      </h3>
+                      <p className="mt-2 max-w-2xl text-sm text-slate-200/80">
+                        These tips help the model understand what matters most in your scene. Try combining them with the AI inspiration suggestions for instant results.
+                      </p>
+                    </>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setIsTipsExpanded((prev) => {
+                      const next = !prev
+                      if (!next) {
+                        setIsTipsHovered(false)
+                      }
+                      return next
+                    })
+                  }
+                  className="inline-flex items-center gap-2 self-start rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-medium text-slate-100 transition hover:border-white/40 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                  aria-expanded={showTipsContent}
+                >
+                  <span>{showTipsContent ? 'Hide tips' : 'Show tips'}</span>
+                  <span
+                    aria-hidden="true"
+                    className={`text-base transition-transform ${showTipsContent ? 'rotate-180' : ''}`}
                   >
-                    <div className="flex items-center justify-between">
-                      <span className="text-xl">{tip.icon}</span>
-                      <span className="h-2 w-2 rounded-full bg-white/60" />
-                    </div>
-                    <h4 className="mt-4 text-base font-semibold text-white">{tip.title}</h4>
-                    <p className="mt-2 text-sm text-slate-100/80">{tip.description}</p>
-                  </div>
-                ))}
+                    ▾
+                  </span>
+                </button>
               </div>
+              {showTipsContent && (
+                <div className="grid w-full gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {quickTips.map((tip) => (
+                    <div
+                      key={tip.title}
+                      className={`rounded-2xl border border-white/10 bg-gradient-to-br ${tip.accent} p-5 text-left shadow-lg backdrop-blur-xl`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-xl">{tip.icon}</span>
+                        <span className="h-2 w-2 rounded-full bg-white/60" />
+                      </div>
+                      <h4 className="mt-4 text-base font-semibold text-white">{tip.title}</h4>
+                      <p className="mt-2 text-sm text-slate-100/80">{tip.description}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/PromptInspiration.tsx
+++ b/src/components/PromptInspiration.tsx
@@ -66,45 +66,59 @@ export default function PromptInspiration({ onUsePrompt, isGenerating = false }:
   }, [isLoading, onUsePrompt, suggestion])
 
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg backdrop-blur-xl">
-      <div className="flex items-center justify-between gap-2 mb-3">
-        <div className="flex items-center gap-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">
-            AI Inspiration
-          </p>
-          <span className="text-[10px] font-medium text-slate-200/70">
-            {source === 'gemini' ? 'Generated with Gemini' : 'Curated example'}
-          </span>
+    <div className="w-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg backdrop-blur-xl">
+      <div className="flex h-full flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-100">
+              AI Inspiration
+            </p>
+            <span className="text-[10px] font-medium text-slate-200/70">
+              {source === 'gemini' ? 'Generated with Gemini' : 'Curated example'}
+            </span>
+          </div>
+          <button
+            onClick={fetchSuggestion}
+            disabled={isLoading || isGenerating}
+            className={`
+              inline-flex items-center gap-2 rounded-lg px-3 py-1 text-xs font-medium transition
+              ${
+                isLoading || isGenerating
+                  ? 'cursor-not-allowed bg-slate-800/50 text-slate-500'
+                  : 'bg-sky-500/20 text-sky-200 hover:bg-sky-500/30 hover:text-sky-100'
+              }
+            `}
+          >
+            {isLoading ? (
+              <>
+                <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                Loading...
+              </>
+            ) : (
+              <>
+                <span role="img" aria-hidden="true">
+                  ✨
+                </span>
+                New idea
+              </>
+            )}
+          </button>
         </div>
-        <button
-          onClick={fetchSuggestion}
-          disabled={isLoading || isGenerating}
-          className={`
-            rounded-lg px-3 py-1 text-xs font-medium transition
-            ${
-              isLoading || isGenerating
-                ? 'cursor-not-allowed bg-slate-800/50 text-slate-500'
-                : 'bg-sky-500/20 text-sky-200 hover:bg-sky-500/30 hover:text-sky-100'
-            }
-          `}
-        >
-          {isLoading ? 'Loading...' : '✨ New idea'}
-        </button>
-      </div>
 
-      <div className="space-y-3">
         <button
           type="button"
           onClick={handleUsePrompt}
           disabled={isLoading || !suggestion}
-          className="group w-full rounded-xl border border-white/10 bg-slate-900/40 px-4 py-3 text-left transition hover:border-white/40 hover:bg-slate-900/60 disabled:cursor-not-allowed disabled:opacity-50"
+          className="group w-full flex-1 rounded-xl border border-white/10 bg-slate-900/40 p-4 text-left transition hover:border-white/40 hover:bg-slate-900/60 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <p className="text-sm font-medium text-sky-200 mb-1">
-            {isLoading ? 'Loading inspiration...' : 'Tap to use this prompt'}
-          </p>
-          <p className="text-xs text-slate-200/80 group-hover:text-slate-100 leading-relaxed">
-            {suggestion}
-          </p>
+          <div className="flex h-full min-h-[120px] flex-col justify-between gap-3">
+            <p className="text-sm font-medium text-sky-200">
+              {isLoading ? 'Loading inspiration...' : 'Tap to use this prompt'}
+            </p>
+            <p className="text-sm leading-relaxed text-slate-200/80 group-hover:text-slate-100">
+              {suggestion}
+            </p>
+          </div>
         </button>
 
         {isLoading && (
@@ -114,9 +128,7 @@ export default function PromptInspiration({ onUsePrompt, isGenerating = false }:
           </div>
         )}
 
-        {message && (
-          <p className="text-xs text-amber-300/80">{message}</p>
-        )}
+        {message && <p className="text-xs text-amber-300/80">{message}</p>}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- restyle the AI Inspiration card to fill the prompt editor width/height and improve the refresh button feedback
- remove the static Prompt inspiration preset block from the image generator panel
- collapse the quick tips panel until the user hovers or selects it, with a new toggle control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cecce9c5c883328c7ca8fbeeaa9172