### PR TITLE
Allow uploaded images to share hero display

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import { AuthProvider } from '@/context/AuthContext'
+import { CanvasImageProvider } from '@/context/CanvasImageContext'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -19,7 +20,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${inter.className} bg-slate-950 text-slate-100 antialiased`}>
         <AuthProvider>
-          {children}
+          <CanvasImageProvider>
+            {children}
+          </CanvasImageProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/ImageDisplay.tsx
+++ b/src/components/ImageDisplay.tsx
@@ -8,6 +8,7 @@ interface ImageDisplayProps {
   isLoading: boolean
   error: string | null
   prompt: string
+  promptLabel?: string
   onRetry?: () => void
   onRegenerate?: () => void
   onClear?: () => void
@@ -20,6 +21,7 @@ export default function ImageDisplay({
   isLoading,
   error,
   prompt,
+  promptLabel,
   onRetry,
   onRegenerate,
   onClear,
@@ -108,6 +110,7 @@ export default function ImageDisplay({
     : 'mt-3 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700'
 
   const promptLabelClass = isHero ? 'font-semibold text-white' : 'font-medium'
+  const promptTitle = promptLabel ?? 'Prompt'
 
   const emptyFrameClass = isHero
     ? 'relative aspect-[3/4] sm:aspect-[4/5] lg:aspect-[5/6] overflow-hidden rounded-3xl border-2 border-dashed border-white/25 bg-white/5 backdrop-blur-2xl shadow-[0_30px_100px_-45px_rgba(59,130,246,0.5)]'
@@ -264,7 +267,7 @@ export default function ImageDisplay({
         {!isImageLoading && !imageError && prompt && (
           <div className={promptInfoClass}>
             <p className="text-sm">
-              <span className={promptLabelClass}>Prompt:</span> {prompt}
+              <span className={promptLabelClass}>{promptTitle}:</span> {prompt}
             </p>
           </div>
         )}
@@ -282,9 +285,9 @@ export default function ImageDisplay({
               <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
             </svg>
           </div>
-          <h3 className={emptyTitleClass}>Your Generated Image</h3>
+          <h3 className={emptyTitleClass}>Your Generated or Uploaded Image</h3>
           <p className={emptyDescriptionClass}>
-            Enter a prompt above and click generate to create your AI image
+            Enter a prompt above, generate an image, or upload your own photo to see it here
           </p>
         </div>
       </div>

--- a/src/context/CanvasImageContext.tsx
+++ b/src/context/CanvasImageContext.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
+import { applyFilterToImageDataUrl, ImageFilter } from '@/lib/imageFilters'
+
+export type CanvasImageSource = 'generated' | 'uploaded'
+
+interface CanvasImage {
+  id: number
+  source: CanvasImageSource
+  originalUrl: string
+  displayUrl: string
+  prompt?: string
+  originalDataUrl?: string
+}
+
+interface ShowUploadedImageOptions {
+  prompt?: string
+  initialFilter?: ImageFilter
+}
+
+interface CanvasImageContextValue {
+  currentImage: CanvasImage | null
+  filter: ImageFilter
+  isProcessing: boolean
+  error: string | null
+  showGeneratedImage: (url: string, prompt?: string) => void
+  showUploadedImage: (dataUrl: string, options?: ShowUploadedImageOptions) => Promise<void>
+  applyFilter: (nextFilter: ImageFilter) => Promise<void>
+  clearImage: () => void
+}
+
+const CanvasImageContext = createContext<CanvasImageContextValue | undefined>(undefined)
+
+const convertUrlToDataUrl = async (url: string): Promise<string> => {
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch the image for processing.')
+  }
+
+  const blob = await response.blob()
+
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+        return
+      }
+      reject(new Error('Unsupported image format encountered during processing.'))
+    }
+    reader.onerror = () => {
+      reject(new Error('Unable to read the image data for processing.'))
+    }
+    reader.readAsDataURL(blob)
+  })
+}
+
+export function CanvasImageProvider({ children }: { children: React.ReactNode }) {
+  const nextIdRef = useRef(1)
+  const [currentImage, setCurrentImage] = useState<CanvasImage | null>(null)
+  const [filter, setFilter] = useState<ImageFilter>('none')
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const runFilterPipeline = useCallback(
+    async (image: CanvasImage, nextFilter: ImageFilter, baseDataUrl?: string) => {
+      if (nextFilter === 'none') {
+        setFilter('none')
+        setError(null)
+        setCurrentImage((prev) => {
+          if (!prev || prev.id !== image.id) {
+            return prev
+          }
+
+          return {
+            ...prev,
+            displayUrl: prev.originalUrl,
+          }
+        })
+        return
+      }
+
+      setIsProcessing(true)
+      setError(null)
+
+      try {
+        const sourceDataUrl =
+          baseDataUrl ??
+          (image.originalDataUrl
+            ? image.originalDataUrl
+            : await convertUrlToDataUrl(image.originalUrl))
+
+        const processedDataUrl = await applyFilterToImageDataUrl(sourceDataUrl, nextFilter)
+
+        setCurrentImage((prev) => {
+          if (!prev || prev.id !== image.id) {
+            return prev
+          }
+
+          return {
+            ...prev,
+            displayUrl: processedDataUrl,
+            originalDataUrl: sourceDataUrl,
+          }
+        })
+        setFilter(nextFilter)
+      } catch (processingError) {
+        console.error('Failed to apply filter to canvas image:', processingError)
+        setError(
+          processingError instanceof Error
+            ? processingError.message
+            : 'Failed to apply the selected filter to the image.'
+        )
+      } finally {
+        setIsProcessing(false)
+      }
+    },
+    []
+  )
+
+  const showGeneratedImage = useCallback((url: string, prompt?: string) => {
+    const image: CanvasImage = {
+      id: nextIdRef.current++,
+      source: 'generated',
+      originalUrl: url,
+      displayUrl: url,
+      prompt,
+    }
+
+    setCurrentImage(image)
+    setFilter('none')
+    setError(null)
+    setIsProcessing(false)
+  }, [])
+
+  const showUploadedImage = useCallback(
+    async (dataUrl: string, options?: ShowUploadedImageOptions) => {
+      const image: CanvasImage = {
+        id: nextIdRef.current++,
+        source: 'uploaded',
+        originalUrl: dataUrl,
+        originalDataUrl: dataUrl,
+        displayUrl: dataUrl,
+        prompt: options?.prompt,
+      }
+
+      setCurrentImage(image)
+      setError(null)
+
+      const initialFilter = options?.initialFilter ?? 'none'
+      setFilter(initialFilter)
+
+      if (initialFilter !== 'none') {
+        await runFilterPipeline(image, initialFilter, dataUrl)
+      }
+    },
+    [runFilterPipeline]
+  )
+
+  const applyFilter = useCallback(
+    async (nextFilter: ImageFilter) => {
+      if (!currentImage) {
+        setFilter(nextFilter)
+        return
+      }
+
+      await runFilterPipeline(currentImage, nextFilter)
+    },
+    [currentImage, runFilterPipeline]
+  )
+
+  const clearImage = useCallback(() => {
+    setCurrentImage(null)
+    setFilter('none')
+    setIsProcessing(false)
+    setError(null)
+  }, [])
+
+  const value: CanvasImageContextValue = {
+    currentImage,
+    filter,
+    isProcessing,
+    error,
+    showGeneratedImage,
+    showUploadedImage,
+    applyFilter,
+    clearImage,
+  }
+
+  return <CanvasImageContext.Provider value={value}>{children}</CanvasImageContext.Provider>
+}
+
+export function useCanvasImage(): CanvasImageContextValue {
+  const context = useContext(CanvasImageContext)
+
+  if (!context) {
+    throw new Error('useCanvasImage must be used within a CanvasImageProvider')
+  }
+
+  return context
+}

--- a/src/hooks/useImageGeneration.ts
+++ b/src/hooks/useImageGeneration.ts
@@ -6,6 +6,7 @@ import nanoBananaAPI from '@/lib/nanoBananaAPI'
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { storage } from '@/lib/firebase'
 import { useAuth } from '@/context/AuthContext'
+import { useCanvasImage } from '@/context/CanvasImageContext'
 
 const MAX_PROMPT_SLUG_LENGTH = 60
 
@@ -37,6 +38,7 @@ const formatTwoDigits = (value: number): string => value.toString().padStart(2, 
 
 export function useImageGeneration(): UseImageGenerationReturn {
   const { user } = useAuth()
+  const { showGeneratedImage, clearImage } = useCanvasImage()
   const [prompt, setPrompt] = useState('')
   const [generatedImage, setGeneratedImage] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -72,6 +74,9 @@ export function useImageGeneration(): UseImageGenerationReturn {
 
         const response = await nanoBananaAPI.generateImage(sanitizedPrompt)
         setGeneratedImage(response.imageUrl)
+        if (response.imageUrl) {
+          showGeneratedImage(response.imageUrl, sanitizedPrompt)
+        }
 
         // Auto-save to Firebase Storage if user is logged in
         if (user && response.imageUrl) {
@@ -127,7 +132,7 @@ export function useImageGeneration(): UseImageGenerationReturn {
         setIsLoading(false)
       }
     },
-    [prompt, user]
+    [prompt, showGeneratedImage, user]
   )
 
   const clearError = useCallback(() => {
@@ -139,7 +144,8 @@ export function useImageGeneration(): UseImageGenerationReturn {
     setGeneratedImage(null)
     setError(null)
     setIsLoading(false)
-  }, [])
+    clearImage()
+  }, [clearImage])
 
   return {
     prompt,

--- a/src/lib/imageFilters.ts
+++ b/src/lib/imageFilters.ts
@@ -1,0 +1,67 @@
+'use client'
+
+export type ImageFilter = 'none' | 'grayscale' | 'sepia' | 'invert'
+
+export const applyFilterToImageDataUrl = async (
+  sourceDataUrl: string,
+  filter: ImageFilter
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    if (filter === 'none') {
+      resolve(sourceDataUrl)
+      return
+    }
+
+    const imageElement = document.createElement('img')
+    imageElement.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = imageElement.width
+      canvas.height = imageElement.height
+
+      const context = canvas.getContext('2d')
+      if (!context) {
+        reject(new Error('Unable to process image: Canvas not supported.'))
+        return
+      }
+
+      context.drawImage(imageElement, 0, 0)
+      const imageData = context.getImageData(0, 0, canvas.width, canvas.height)
+      const { data } = imageData
+
+      for (let index = 0; index < data.length; index += 4) {
+        const red = data[index]
+        const green = data[index + 1]
+        const blue = data[index + 2]
+
+        if (filter === 'grayscale') {
+          const average = 0.299 * red + 0.587 * green + 0.114 * blue
+          data[index] = average
+          data[index + 1] = average
+          data[index + 2] = average
+          continue
+        }
+
+        if (filter === 'sepia') {
+          data[index] = Math.min(0.393 * red + 0.769 * green + 0.189 * blue, 255)
+          data[index + 1] = Math.min(0.349 * red + 0.686 * green + 0.168 * blue, 255)
+          data[index + 2] = Math.min(0.272 * red + 0.534 * green + 0.131 * blue, 255)
+          continue
+        }
+
+        if (filter === 'invert') {
+          data[index] = 255 - red
+          data[index + 1] = 255 - green
+          data[index + 2] = 255 - blue
+        }
+      }
+
+      context.putImageData(imageData, 0, 0)
+      resolve(canvas.toDataURL('image/png'))
+    }
+
+    imageElement.onerror = () => {
+      reject(new Error('Failed to load the selected image for processing.'))
+    }
+
+    imageElement.src = sourceDataUrl
+  })


### PR DESCRIPTION
## Summary
- add a shared canvas image context so generated and uploaded images feed the hero display
- update the hero generator UI with unified filter controls and prompt labeling for uploaded photos
- rework the uploader to push selected files into the shared display and reuse the filtering pipeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee8c24e2883329338ab2c7dc3a6e9