### PR TITLE
Enable Nano Banana hero image editing workflow

### DIFF
--- a/src/app/api/edit-image/route.ts
+++ b/src/app/api/edit-image/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+interface EditImageRequestBody {
+  imageDataUrl?: string
+  instruction?: string
+}
+
+const DATA_URL_REGEX = /^data:([^;]+);base64,(.+)$/
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = (await request.json()) as EditImageRequestBody
+    const instruction = body.instruction?.trim() ?? ''
+    const imageDataUrl = body.imageDataUrl?.trim() ?? ''
+
+    if (!imageDataUrl) {
+      return NextResponse.json(
+        { error: 'imageDataUrl is required so Nano Banana can edit the current canvas.' },
+        { status: 400 }
+      )
+    }
+
+    const dataUrlMatch = imageDataUrl.match(DATA_URL_REGEX)
+
+    if (!dataUrlMatch) {
+      return NextResponse.json(
+        { error: 'imageDataUrl must be a base64 encoded data URL.' },
+        { status: 400 }
+      )
+    }
+
+    if (!instruction) {
+      return NextResponse.json(
+        { error: 'Provide editing instructions so Nano Banana knows what to change.' },
+        { status: 400 }
+      )
+    }
+
+    if (instruction.length < 3) {
+      return NextResponse.json(
+        { error: 'Editing instructions must be at least 3 characters long.' },
+        { status: 400 }
+      )
+    }
+
+    if (instruction.length > 500) {
+      return NextResponse.json(
+        { error: 'Editing instructions must be less than 500 characters.' },
+        { status: 400 }
+      )
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY
+
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'Gemini API key not configured on server' },
+        { status: 500 }
+      )
+    }
+
+    const [, mimeType, base64Data] = dataUrlMatch
+
+    const genAI = new GoogleGenerativeAI(apiKey)
+    const model = genAI.getGenerativeModel({
+      model: 'gemini-2.5-flash-image-preview'
+    })
+
+    const result = await model.generateContent({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                data: base64Data,
+                mimeType,
+              }
+            },
+            {
+              text: `Apply these changes to the provided image: ${instruction}. Return only the edited image.`
+            }
+          ]
+        }
+      ]
+    })
+
+    const response = result.response
+    const imagePart = response.candidates?.[0]?.content?.parts?.find(
+      part => (part as { inlineData?: unknown }).inlineData
+    ) as { inlineData?: { data?: string; mimeType?: string } } | undefined
+
+    if (!imagePart?.inlineData?.data) {
+      return NextResponse.json(
+        { error: 'No edited image was returned from Gemini.' },
+        { status: 500 }
+      )
+    }
+
+    const editedImageData = imagePart.inlineData.data
+    const editedMimeType = imagePart.inlineData.mimeType ?? 'image/png'
+    const imageUrl = `data:${editedMimeType};base64,${editedImageData}`
+
+    return NextResponse.json({
+      imageUrl,
+      id: Math.random().toString(36).substring(7),
+      metadata: {
+        model: 'gemini-2.5-flash-image-preview',
+        dimensions: {
+          width: 1024,
+          height: 1024
+        },
+        generatedAt: new Date(),
+        prompt: instruction,
+      }
+    })
+  } catch (error) {
+    console.error('Gemini image edit error:', error)
+
+    let errorMessage = 'An unexpected error occurred while editing the image'
+    let statusCode = 500
+
+    if (error instanceof Error) {
+      if (error.message.includes('quota') || error.message.includes('limit')) {
+        errorMessage = 'API quota exceeded. Please try again later.'
+        statusCode = 429
+      } else if (error.message.includes('invalid') || error.message.includes('authentication')) {
+        errorMessage = 'Invalid API key. Please check your Gemini API configuration.'
+        statusCode = 401
+      } else if (error.message.includes('safety') || error.message.includes('content')) {
+        errorMessage = 'Content policy violation. Please try a different instruction.'
+        statusCode = 400
+      } else {
+        errorMessage = `Failed to edit image: ${error.message}`
+      }
+    }
+
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: statusCode }
+    )
+  }
+}

--- a/src/context/CanvasImageContext.tsx
+++ b/src/context/CanvasImageContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useRef, useState } from 'react'
 import { applyFilterToImageDataUrl, ImageFilter } from '@/lib/imageFilters'
+import { convertImageUrlToDataUrl } from '@/lib/imageData'
 
 export type CanvasImageSource = 'generated' | 'uploaded'
 
@@ -31,31 +32,6 @@ interface CanvasImageContextValue {
 }
 
 const CanvasImageContext = createContext<CanvasImageContextValue | undefined>(undefined)
-
-const convertUrlToDataUrl = async (url: string): Promise<string> => {
-  const response = await fetch(url)
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch the image for processing.')
-  }
-
-  const blob = await response.blob()
-
-  return await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      if (typeof reader.result === 'string') {
-        resolve(reader.result)
-        return
-      }
-      reject(new Error('Unsupported image format encountered during processing.'))
-    }
-    reader.onerror = () => {
-      reject(new Error('Unable to read the image data for processing.'))
-    }
-    reader.readAsDataURL(blob)
-  })
-}
 
 export function CanvasImageProvider({ children }: { children: React.ReactNode }) {
   const nextIdRef = useRef(1)
@@ -90,7 +66,7 @@ export function CanvasImageProvider({ children }: { children: React.ReactNode })
           baseDataUrl ??
           (image.originalDataUrl
             ? image.originalDataUrl
-            : await convertUrlToDataUrl(image.originalUrl))
+            : await convertImageUrlToDataUrl(image.originalUrl))
 
         const processedDataUrl = await applyFilterToImageDataUrl(sourceDataUrl, nextFilter)
 

--- a/src/hooks/useImageRemix.ts
+++ b/src/hooks/useImageRemix.ts
@@ -1,0 +1,93 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import nanoBananaAPI from '@/lib/nanoBananaAPI'
+import { useCanvasImage } from '@/context/CanvasImageContext'
+import { convertImageUrlToDataUrl } from '@/lib/imageData'
+import { NanoBananaAPIResponse } from '@/types'
+
+interface UseImageRemixReturn {
+  instruction: string
+  setInstruction: (value: string) => void
+  isRemixing: boolean
+  error: string | null
+  lastInstruction: string | null
+  remixImage: (instructionOverride?: string) => Promise<NanoBananaAPIResponse | null>
+  clearError: () => void
+}
+
+export function useImageRemix(): UseImageRemixReturn {
+  const { currentImage, showGeneratedImage } = useCanvasImage()
+  const [instruction, setInstruction] = useState('')
+  const [isRemixing, setIsRemixing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [lastInstruction, setLastInstruction] = useState<string | null>(null)
+
+  useEffect(() => {
+    setInstruction('')
+    setError(null)
+  }, [currentImage?.id])
+
+  const remixImage = useCallback(
+    async (instructionOverride?: string): Promise<NanoBananaAPIResponse | null> => {
+      if (!currentImage) {
+        setError('Load or generate an image before asking Nano Banana to edit it.')
+        return null
+      }
+
+      const instructionToUse = (instructionOverride ?? instruction).trim()
+
+      if (!instructionToUse) {
+        setError('Describe the changes you want before sending the image to Nano Banana.')
+        return null
+      }
+
+      if (instructionToUse.length < 3) {
+        setError('Please provide at least a few words describing the edit you need.')
+        return null
+      }
+
+      try {
+        setIsRemixing(true)
+        setError(null)
+
+        const dataUrl = await convertImageUrlToDataUrl(currentImage.displayUrl)
+        const response = await nanoBananaAPI.editImage({
+          imageDataUrl: dataUrl,
+          instruction: instructionToUse,
+        })
+
+        showGeneratedImage(response.imageUrl, instructionToUse)
+        setInstruction('')
+        setLastInstruction(instructionToUse)
+
+        return response
+      } catch (remixError) {
+        console.error('Failed to edit image with Nano Banana:', remixError)
+        setError(
+          remixError instanceof Error
+            ? remixError.message
+            : 'Failed to edit the image. Please try again.'
+        )
+        return null
+      } finally {
+        setIsRemixing(false)
+      }
+    },
+    [currentImage, instruction, showGeneratedImage]
+  )
+
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  return {
+    instruction,
+    setInstruction,
+    isRemixing,
+    error,
+    lastInstruction,
+    remixImage,
+    clearError,
+  }
+}

--- a/src/lib/imageData.ts
+++ b/src/lib/imageData.ts
@@ -1,0 +1,38 @@
+'use client'
+
+/**
+ * Convert any accessible image URL into a base64 data URL so it can be sent to APIs
+ * that require inline image data. Data URLs are returned unchanged.
+ */
+export async function convertImageUrlToDataUrl(imageUrl: string): Promise<string> {
+  if (!imageUrl) {
+    throw new Error('No image available to convert.')
+  }
+
+  if (imageUrl.startsWith('data:')) {
+    return imageUrl
+  }
+
+  const response = await fetch(imageUrl)
+
+  if (!response.ok) {
+    throw new Error('Failed to download the image for processing.')
+  }
+
+  const blob = await response.blob()
+
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+        return
+      }
+      reject(new Error('Unsupported image format encountered during conversion.'))
+    }
+    reader.onerror = () => {
+      reject(new Error('Unable to read the image data for conversion.'))
+    }
+    reader.readAsDataURL(blob)
+  })
+}

--- a/src/lib/nanoBananaAPI.ts
+++ b/src/lib/nanoBananaAPI.ts
@@ -1,4 +1,4 @@
-import { NanoBananaAPI, NanoBananaAPIResponse } from '@/types'
+import { NanoBananaAPI, NanoBananaAPIResponse, NanoBananaImageEditRequest } from '@/types'
 
 // Mock implementation for development
 // This will be replaced with actual API integration later
@@ -26,6 +26,31 @@ class MockNanoBananaAPI implements NanoBananaAPI {
         },
         generatedAt: new Date(),
         prompt,
+      }
+    }
+  }
+
+  async editImage({ instruction }: NanoBananaImageEditRequest): Promise<NanoBananaAPIResponse> {
+    await new Promise(resolve => setTimeout(resolve, 2000 + Math.random() * 3000))
+
+    if (Math.random() < 0.1) {
+      throw new Error('Failed to apply the requested changes. Please try again.')
+    }
+
+    const mockImageId = Math.random().toString(36).substring(7)
+    const normalizedInstruction = encodeURIComponent(instruction.trim() || 'edit')
+
+    return {
+      imageUrl: `https://picsum.photos/seed/${normalizedInstruction}-${mockImageId}/1024/1024`,
+      id: mockImageId,
+      metadata: {
+        model: 'nano-banana-v1-mock-edit',
+        dimensions: {
+          width: 1024,
+          height: 1024
+        },
+        generatedAt: new Date(),
+        prompt: instruction,
       }
     }
   }
@@ -58,6 +83,34 @@ class NanoBananaAPIClient implements NanoBananaAPI {
       }
 
       throw new Error('An unexpected error occurred while generating the image')
+    }
+  }
+
+  async editImage(request: NanoBananaImageEditRequest): Promise<NanoBananaAPIResponse> {
+    try {
+      const response = await fetch('/api/edit-image', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request)
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to edit the image')
+      }
+
+      return data
+    } catch (error) {
+      console.error('API Error:', error)
+
+      if (error instanceof Error) {
+        throw error
+      }
+
+      throw new Error('An unexpected error occurred while editing the image')
     }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,8 +31,14 @@ export interface NanoBananaAPIResponse {
   metadata: ImageMetadata
 }
 
+export interface NanoBananaImageEditRequest {
+  imageDataUrl: string
+  instruction: string
+}
+
 export interface NanoBananaAPI {
   generateImage(prompt: string): Promise<NanoBananaAPIResponse>
+  editImage(request: NanoBananaImageEditRequest): Promise<NanoBananaAPIResponse>
 }
 
 export interface PromptSuggestionResponse {


### PR DESCRIPTION
## Summary
- add a Nano Banana remix panel in the hero generator so users can send the current image with instructions
- create a `useImageRemix` hook plus image conversion helper to package the active canvas for edits
- expose `/api/edit-image` and extend the Nano Banana API client/types to support instruction-driven image updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef14662b48332929da28ba0260632