### PR TITLE
Handle non-JSON API error responses

### DIFF
--- a/src/lib/nanoBananaAPI.ts
+++ b/src/lib/nanoBananaAPI.ts
@@ -86,6 +86,61 @@ class MockNanoBananaAPI implements NanoBananaAPI {
   }
 }
 
+async function parseNanoBananaResponse<T>(response: Response): Promise<T> {
+  const contentType = response.headers.get('content-type') ?? ''
+  const responseText = await response.text()
+  const trimmedText = responseText.trim()
+  const isJsonResponse = contentType.includes('application/json')
+
+  let parsedData: unknown
+  let parsedJsonSuccessfully = false
+
+  if (isJsonResponse) {
+    try {
+      parsedData = JSON.parse(responseText)
+      parsedJsonSuccessfully = true
+    } catch {
+      parsedJsonSuccessfully = false
+    }
+  }
+
+  if (!response.ok) {
+    if (response.status === 413) {
+      throw new Error('The uploaded images are too large. Please try again with smaller files.')
+    }
+
+    if (
+      parsedJsonSuccessfully &&
+      parsedData &&
+      typeof parsedData === 'object' &&
+      'error' in parsedData &&
+      typeof (parsedData as { error?: unknown }).error === 'string'
+    ) {
+      throw new Error((parsedData as { error: string }).error)
+    }
+
+    if (trimmedText.length > 0) {
+      throw new Error(trimmedText)
+    }
+
+    throw new Error(`Request failed with status ${response.status}`)
+  }
+
+  if (parsedJsonSuccessfully && parsedData && typeof parsedData === 'object') {
+    return parsedData as T
+  }
+
+  if (isJsonResponse) {
+    throw new Error('Failed to parse the server response. Please try again later.')
+  }
+
+  if (trimmedText.length === 0) {
+    throw new Error('Received empty response from the server.')
+  }
+
+  throw new Error('Unexpected response format received from the server.')
+}
+
 // Production API implementation using server-side endpoint
 class NanoBananaAPIClient implements NanoBananaAPI {
   async generateImage(prompt: string): Promise<NanoBananaAPIResponse> {
@@ -98,13 +153,7 @@ class NanoBananaAPIClient implements NanoBananaAPI {
         body: JSON.stringify({ prompt })
       })
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to generate image')
-      }
-
-      return data
+      return await parseNanoBananaResponse<NanoBananaAPIResponse>(response)
     } catch (error) {
       console.error('API Error:', error)
 
@@ -126,13 +175,7 @@ class NanoBananaAPIClient implements NanoBananaAPI {
         body: JSON.stringify(request)
       })
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to edit the image')
-      }
-
-      return data
+      return await parseNanoBananaResponse<NanoBananaAPIResponse>(response)
     } catch (error) {
       console.error('API Error:', error)
 
@@ -154,13 +197,7 @@ class NanoBananaAPIClient implements NanoBananaAPI {
         body: JSON.stringify(request)
       })
 
-      const data = await response.json()
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Failed to transfuse the images')
-      }
-
-      return data
+      return await parseNanoBananaResponse<NanoBananaAPIResponse>(response)
     } catch (error) {
       console.error('API Error:', error)
 


### PR DESCRIPTION
## Summary
- add a shared response parser that surfaces text-based API errors (e.g. large payload errors)
- route all production API client requests through the parser for consistent handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1826ba6c8332993b470f91d5c3b7